### PR TITLE
BUG 1769704: fix OMPS publish validation error

### DIFF
--- a/manifests/4.3/ptp-operator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/ptp-operator.v4.3.0.clusterserviceversion.yaml
@@ -43,6 +43,15 @@ metadata:
         },
         {
           "apiVersion": "ptp.openshift.io/v1",
+          "kind": "NodePtpDevice",
+          "metadata": {
+            "name": "node.example.com",
+            "namespace": "openshift-ptp"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "ptp.openshift.io/v1",
           "kind": "PtpOperatorConfig",
           "metadata": {
             "name": "default",

--- a/manifests/4.3/ptp-operator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/ptp-operator.v4.3.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-ptp
   annotations:
     capabilities: Basic Install
-    categories: "Time"
+    categories: Networking
     provider: Red Hat
     support: Red Hat
     containerImage: quay.io/openshift/origin-ptp-operator:4.3

--- a/manifests/4.4/ptp-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/ptp-operator.v4.4.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-ptp
   annotations:
     capabilities: Basic Install
-    categories: "Time"
+    categories: Networking
     provider: Red Hat
     support: Red Hat
     containerImage: quay.io/openshift/origin-ptp-operator:4.4

--- a/manifests/4.4/ptp-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/ptp-operator.v4.4.0.clusterserviceversion.yaml
@@ -43,6 +43,15 @@ metadata:
         },
         {
           "apiVersion": "ptp.openshift.io/v1",
+          "kind": "NodePtpDevice",
+          "metadata": {
+            "name": "node.example.com",
+            "namespace": "openshift-ptp"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "ptp.openshift.io/v1",
           "kind": "PtpOperatorConfig",
           "metadata": {
             "name": "default",


### PR DESCRIPTION

Operator Courier version:
-------------------------

2.1.7 (https://github.com/operator-framework/operator-courier/releases/tag/v2.1.7)

Validation Warnings:
--------------------

"NodePtpDevice CRD does not have an entry in alm-examples - please add such an example CR."

Validation Errors:
------------------

"category Time is not a valid category"
"UI validation failed to verify that required fields for operatorhub.io are properly formatted."

stderr: 
-------

WARNING: NodePtpDevice CRD does not have an entry in alm-examples - please add such an example CR. [37173e54-8375-4d0f-a1f8-4166299beff0/ptp-operator.package.yaml]
ERROR: category Time is not a valid category [37173e54-8375-4d0f-a1f8-4166299beff0/ptp-operator.package.yaml]
ERROR: UI validation failed to verify that required fields for operatorhub.io are properly formatted. [37173e54-8375-4d0f-a1f8-4166299beff0/ptp-operator.package.yaml]
Resulting bundle is invalid, input yaml is improperly defined.