### PR TITLE
Bug 1775630: support pre-release version upgrade in olm.skipRange

### DIFF
--- a/manifests/4.3/ptp-operator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/ptp-operator.v4.3.0.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     createdAt: 2019-10-14
     certified: "false"
     repository: https://github.com/openshift/ptp-operator
-    olm.skipRange: ">=4.3.0 <4.3.0"
+    olm.skipRange: ">=4.3.0-0 <4.3.0"
     alm-examples: |-
       [
         {

--- a/manifests/4.4/ptp-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/ptp-operator.v4.4.0.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     createdAt: 2019-10-14
     certified: "false"
     repository: https://github.com/openshift/ptp-operator
-    olm.skipRange: ">=4.3.0 <4.4.0"
+    olm.skipRange: ">=4.3.0-0 <4.4.0"
     alm-examples: |-
       [
         {

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -6,8 +6,8 @@ updates:
       replace: "ptp-operator.{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.3.0 <{MAJOR}.{MINOR}.0"'
-      replace: 'olm.skipRange: ">=4.3.0 <{FULL_VER}"'
+    - search: 'olm.skipRange: ">=4.3.0-0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.3.0-0 <{FULL_VER}"'
   - file: "ptp-operator.package.yaml"
     update_list:
     - search: "currentCSV: ptp-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
When major, minor, and patch are equal, a pre-release
version has lower precedence than a normal version.
Example: 1.0.0-alpha < 1.0.0.