### PR TITLE
Fix cluster role for the operator

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -37,7 +37,7 @@ rules:
   resources: ["servicemonitors"]
   verbs: ["*"]
 - apiGroups: ["monitoring.coreos.com"]
-  resources: ["prometheusrule"]
+  resources: ["prometheusrules"]
   verbs: ["*"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles"]

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -24,6 +24,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  - prometheusrules
   verbs:
   - get
   - create

--- a/manifests/4.4/ptp-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/ptp-operator.v4.4.0.clusterserviceversion.yaml
@@ -158,7 +158,7 @@ spec:
           - monitoring.coreos.com
           resources:
           - servicemonitors
-          - prometheusrule
+          - prometheusrules
           verbs:
           - '*'
         - apiGroups:


### PR DESCRIPTION
This PR fix a small typo for the cluster rule.

Error:
```
2020/01/27 08:59:00 reconciling (monitoring.coreos.com/v1, Kind=PrometheusRule) openshift-ptp/ptp-rules
{"level":"error","ts":1580115540.2768207,"logger":"kubebuilder.controller","msg":"Reconciler error","controller":"ptpoperatorconfig-controller","request":"openshift-ptp/default","error":"failed to apply object &{map[apiVersion:monitoring.coreos.com/v1 kind:PrometheusRule metadata:map[labels:map[prometheus:k8s role:alert-rules] name:ptp-rules namespace:openshift-ptp ownerReferences:[map[apiVersion:ptp.openshift.io/v1 blockOwnerDeletion:true controller:true kind:PtpOperatorConfig name:default uid:fa7327e8-9993-4c8b-a5ce-60a7e40d4c38]]] spec:map[groups:[map[name:ptp.rules rules:[map[alert:NodeOutOfPtpSync annotations:map[message:All nodes should have ptp sync offset lower then 100\n] expr:openshift_ptp_max_offset_from_master > 100 or openshift_ptp_max_offset_from_master < -100\n for:2m labels:map[severity:warning]]]]]]]} with err: could not retrieve existing (monitoring.coreos.com/v1, Kind=PrometheusRule) openshift-ptp/ptp-rules: prometheusrules.monitoring.coreos.com \"ptp-rules\" is forbidden: User \"system:serviceaccount:openshift-ptp:ptp-operator\" cannot get resource \"prometheusrules\" in API group \"monitoring.coreos.com\" in the namespace \"openshift-ptp\"","stacktrace":"github.com/openshift/ptp-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/openshift/ptp-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/ptp-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/openshift/ptp-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:217\ngithub.com/openshift/ptp-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/go/src/github.com/openshift/ptp-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/openshift/ptp-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/openshift/ptp-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/openshift/ptp-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/openshift/ptp-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/openshift/ptp-operator/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/openshift/ptp-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
{"level":"info","ts":1580115541.5569785,"logger":"controller_ptpoperatorconfig","msg":"Reconciling PtpOperatorConfig","Request.Namespace":"openshift-ptp","Request.Name":"default"}
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>