### PR TITLE
Fix cluster-scope issue

### DIFF
--- a/hack/env.sh
+++ b/hack/env.sh
@@ -2,7 +2,8 @@ REPO_DIR="$(dirname $0)/.."
 NAMESPACE=openshift-ptp
 OPERATOR_EXEC=oc
 
-export RELEASE_VERSION=v4.3.0
+export RELEASE_VERSION=v4.5.0
+export IMAGE_TAG=latest
 export OPERATOR_NAME=ptp-operator
 
 LINUXPTP_DAEMON_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-ptp | jq --raw-output '.Digest')

--- a/pkg/controller/ptpoperatorconfig/ptpoperatorconfig_controller.go
+++ b/pkg/controller/ptpoperatorconfig/ptpoperatorconfig_controller.go
@@ -142,10 +142,6 @@ func (r *ReconcilePtpOperatorConfig) createPTPConfigMap(defaultCfg *ptpv1.PtpOpe
 	var err error
 
 	cm := &corev1.ConfigMap{}
-	if err = controllerutil.SetControllerReference(defaultCfg, cm, r.scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference: %v", err)
-	}
-
 	err = r.client.Get(context.TODO(), types.NamespacedName{
 		Namespace: names.Namespace, Name: names.DefaultPTPConfigMapName}, cm)
 	if err != nil {
@@ -153,6 +149,11 @@ func (r *ReconcilePtpOperatorConfig) createPTPConfigMap(defaultCfg *ptpv1.PtpOpe
 			cm.Name = names.DefaultPTPConfigMapName
 			cm.Namespace = names.Namespace
 			cm.Data = make(map[string]string)
+
+			if err = controllerutil.SetControllerReference(defaultCfg, cm, r.scheme); err != nil {
+				return fmt.Errorf("failed to set owner reference: %v", err)
+			}
+
 			err = r.client.Create(context.TODO(), cm)
 			if err != nil {
 				return fmt.Errorf("failed to create ptp config map: %v", err)


### PR DESCRIPTION
This commit also change the env.sh file to use latest image.

The scope is related to the controller-runtime update.

https://github.com/kubernetes-sigs/controller-runtime/pull/675/files

Signed-off-by: Sebastian Sch <sebassch@gmail.com>