### PR TITLE
Bug 1826302: Make the tests exportable.

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -10,13 +10,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	_ "github.com/openshift/ptp-operator/test/ptp"
 	testutils "github.com/openshift/ptp-operator/test/utils"
 	testclient "github.com/openshift/ptp-operator/test/utils/client"
 	"github.com/openshift/ptp-operator/test/utils/namespaces"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TODO: we should refactor tests to use client from controller-runtime package
@@ -40,6 +40,8 @@ func TestTest(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	// create test namespace
+	Expect(testclient.Client).NotTo(BeNil())
+
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testutils.NamespaceTesting,

--- a/test/utils/client/clients.go
+++ b/test/utils/client/clients.go
@@ -49,7 +49,8 @@ func New(kubeconfig string) *ClientSet {
 		config, err = rest.InClusterConfig()
 	}
 	if err != nil {
-		panic(err)
+		glog.Infof("Failed to create a valid client")
+		return nil
 	}
 
 	clientSet := &ClientSet{}

--- a/test/utils/pods/pods.go
+++ b/test/utils/pods/pods.go
@@ -188,5 +188,5 @@ func ExecCommand(cs *testclient.ClientSet, pod corev1.Pod, command []string) (by
 		Tty:    true,
 	})
 
-	return buf, nil
+	return buf, err
 }


### PR DESCRIPTION
Have them belong to a different package, so they can be vendored.
Do not panic if the client does not get created, but return nil and check for it not to be nil instead.
This allows us to dry run and check what tests are available.

