### PR TITLE
Bug 1830496: Remove runlevel from the operator's namespace and use SCC

### DIFF
--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -5,5 +5,4 @@ metadata:
   name: openshift-ptp
   labels:
     name: openshift-ptp
-    openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -34,3 +34,18 @@ rules:
   - '*'
   verbs:
   - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: linuxptp-daemon
+  namespace: openshift-ptp
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -11,7 +11,9 @@ pushd ${REPO_DIR}/deploy
 		service_account.yaml
 		clusterrole.yaml
 		clusterrolebinding.yaml
-		operator.yaml"
+		operator.yaml
+		role.yaml
+		rolebinding.yaml"
 
 	for f in ${FILES}; do
 		if [ "$(echo ${EXCLUSIONS[@]} | grep -o ${f} | wc -w | xargs)" == "0" ] ; then

--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -6,6 +6,8 @@ pushd ${REPO_DIR}/deploy
 		service_account.yaml
 		clusterrolebinding.yaml
 		clusterrole.yaml
+		role.yaml
+		rolebinding.yaml
 		crds/ptp.openshift.io_nodeptpdevices_crd.yaml
 		crds/ptp.openshift.io_ptpoperatorconfigs_crd.yaml
 		crds/ptp.openshift.io_ptpconfigs_crd.yaml"

--- a/manifests/4.5/ptp-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/ptp-operator.v4.5.0.clusterserviceversion.yaml
@@ -109,7 +109,6 @@ spec:
         name: openshift-ptp
         labels:
           name: openshift-ptp
-          openshift.io/run-level: "1"
           openshift.io/cluster-monitoring: "true"
       EOF
 
@@ -177,6 +176,17 @@ spec:
           verbs:
           - '*'
         serviceAccountName: linuxptp-daemon
+      permissions:
+        - serviceAccountName: linuxptp-daemon
+          rules:
+            - apiGroups:
+              - security.openshift.io
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - use
+              resourceNames:
+              - privileged
       deployments:
       - name: ptp-operator
         spec:


### PR DESCRIPTION
Use the privileged scc for the ptp-daemon.

