### PR TITLE
Adding discovery mode to tests

### DIFF
--- a/test/utils/discovery/discovery.go
+++ b/test/utils/discovery/discovery.go
@@ -1,0 +1,12 @@
+package discovery
+
+import (
+	"os"
+	"strconv"
+)
+
+// DiscoveryModeEnabled indicates whether test discovery mode is enabled.
+func Enabled() bool {
+	discoveryMode, _ := strconv.ParseBool(os.Getenv("DISCOVERY_MODE"))
+	return discoveryMode
+}


### PR DESCRIPTION
A draft patch showing how "discovery mode" for tests can be implemented.
Tests in discovery mode will not perform any environment configuration, but instead try to use existing configuration items. If test prerequisites are not met, the test will be skipped.