### PR TITLE
Provide an optional node selector to choose the nodes impacted by the tests

### DIFF
--- a/test/ptp/ptp.go
+++ b/test/ptp/ptp.go
@@ -297,7 +297,7 @@ func configurePTP() {
 	err := clean.All()
 	Expect(err).ToNot(HaveOccurred())
 
-	ptpNodes, err := nodes.GetNodeTopology(client.Client)
+	ptpNodes, err := nodes.PtpEnabled(client.Client)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(len(ptpNodes)).To(BeNumerically(">", 1), "need at least two nodes with ptp capable nics")
 


### PR DESCRIPTION
While running tests on a cluster, we may want to limit the number of nodes impacted by those nodes.
By providing an optional selector we choose the nodes where to apply the configuration.

Also, refactor the cleaning logic in a separate function so we can invoke it.