### PR TITLE
Export a clean.All() method that removes all the configuration left from the tests.

### DIFF
--- a/test/ptp/ptp.go
+++ b/test/ptp/ptp.go
@@ -21,6 +21,7 @@ import (
 	ptpv1 "github.com/openshift/ptp-operator/pkg/apis/ptp/v1"
 
 	. "github.com/openshift/ptp-operator/test/utils"
+	"github.com/openshift/ptp-operator/test/utils/clean"
 	"github.com/openshift/ptp-operator/test/utils/client"
 	testclient "github.com/openshift/ptp-operator/test/utils/client"
 	"github.com/openshift/ptp-operator/test/utils/discovery"
@@ -293,31 +294,8 @@ var _ = Describe("[ptp]", func() {
 })
 
 func configurePTP() {
-	ptpconfigList, err := client.Client.PtpConfigs(PtpLinuxDaemonNamespace).List(context.Background(), metav1.ListOptions{})
+	err := clean.All()
 	Expect(err).ToNot(HaveOccurred())
-
-	for _, ptpConfig := range ptpconfigList.Items {
-		if ptpConfig.Name == PtpGrandMasterPolicyName || ptpConfig.Name == PtpSlavePolicyName {
-			err = client.Client.PtpConfigs(PtpLinuxDaemonNamespace).Delete(context.Background(), ptpConfig.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-		}
-	}
-
-	nodeList, err := client.Client.Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=", PtpGrandmasterNodeLabel)})
-	Expect(err).ToNot(HaveOccurred())
-	for _, node := range nodeList.Items {
-		delete(node.Labels, PtpGrandmasterNodeLabel)
-		_, err = client.Client.Nodes().Update(context.Background(), &node, metav1.UpdateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	nodeList, err = client.Client.Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=", PtpSlaveNodeLabel)})
-	Expect(err).ToNot(HaveOccurred())
-	for _, node := range nodeList.Items {
-		delete(node.Labels, PtpSlaveNodeLabel)
-		_, err = client.Client.Nodes().Update(context.Background(), &node, metav1.UpdateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-	}
 
 	ptpNodes, err := nodes.GetNodeTopology(client.Client)
 	Expect(err).ToNot(HaveOccurred())

--- a/test/utils/clean/clean.go
+++ b/test/utils/clean/clean.go
@@ -1,0 +1,49 @@
+package clean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/ptp-operator/test/utils"
+	"github.com/openshift/ptp-operator/test/utils/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// All removes any configuration applied by ptp tests.
+func All() error {
+	ptpconfigList, err := client.Client.PtpConfigs(utils.PtpLinuxDaemonNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("clean.All: Failed to retrieve ptp config list %v", err)
+	}
+
+	for _, ptpConfig := range ptpconfigList.Items {
+		if ptpConfig.Name == utils.PtpGrandMasterPolicyName || ptpConfig.Name == utils.PtpSlavePolicyName {
+			err = client.Client.PtpConfigs(utils.PtpLinuxDaemonNamespace).Delete(context.Background(), ptpConfig.Name, metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("clean.All: Failed to delete ptp config %s %v", ptpConfig.Name, err)
+			}
+		}
+	}
+
+	nodeList, err := client.Client.Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=", utils.PtpGrandmasterNodeLabel)})
+	if err != nil {
+		return fmt.Errorf("clean.All: Failed to retrieve grandmaster node list %v", err)
+	}
+	for _, node := range nodeList.Items {
+		delete(node.Labels, utils.PtpGrandmasterNodeLabel)
+		_, err = client.Client.Nodes().Update(context.Background(), &node, metav1.UpdateOptions{})
+	}
+
+	nodeList, err = client.Client.Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=", utils.PtpSlaveNodeLabel)})
+	if err != nil {
+		return fmt.Errorf("clean.All: Failed to retrieve slave node list %v", err)
+	}
+	for _, node := range nodeList.Items {
+		delete(node.Labels, utils.PtpSlaveNodeLabel)
+		_, err = client.Client.Nodes().Update(context.Background(), &node, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("clean.All: Failed to remove label from %s %v", node.Name, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
When vendoring the tests, this allows an external suite to clean any leftovers.
