### PR TITLE
Bug 1884529: Skip the higher profile priority test in discovery mode

### DIFF
--- a/test/ptp/ptp.go
+++ b/test/ptp/ptp.go
@@ -226,6 +226,9 @@ var _ = Describe("[ptp]", func() {
 			//25743
 			It("Can provide a profile with higher priority", func() {
 				var testPtpPod v1core.Pod
+				if discovery.Enabled() {
+					Skip("Skipping because adding a different profile")
+				}
 
 				By("Creating a config with higher priority", func() {
 					ptpConfigSlave, err := client.Client.PtpV1Interface.PtpConfigs("openshift-ptp").Get(context.Background(), PtpSlavePolicyName, metav1.GetOptions{})


### PR DESCRIPTION
In discovery mode we don't want to change the current configuration.
