### PR TITLE
Update paths so that copy works, update to use go 1.15 images

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,8 +1,9 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
-WORKDIR /go/src/github.com/openshift/ptp-operator
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+WORKDIR /go/src/github.com/openshift/ptp-operator/must-gather
 COPY . .
 
-FROM quay.io/openshift/origin-must-gather:4.3.0
+FROM registry.svc.ci.openshift.org/ocp/4.7:must-gather
 COPY --from=builder /go/src/github.com/openshift/ptp-operator/must-gather/collection-scripts/* /usr/bin/
+RUN chmod +x /usr/bin/gather
 
 ENTRYPOINT /usr/bin/gather

--- a/must-gather/Dockerfile.rhel7
+++ b/must-gather/Dockerfile.rhel7
@@ -1,10 +1,11 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
-WORKDIR /go/src/github.com/openshift/ptp-operator
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+WORKDIR /go/src/github.com/openshift/ptp-operator/must-gather
 COPY . .
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:cli
+FROM registry.svc.ci.openshift.org/ocp/4.7:must-gather
 LABEL io.k8s.display-name="ptp-operator-must-gather" \
       io.k8s.description="This is a PTP must-gather image that collectes PTP operator related resources."
 COPY --from=builder /go/src/github.com/openshift/ptp-operator/must-gather/collection-scripts/* /usr/bin/
+RUN chmod +x /usr/bin/gather
 
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
Got a heads up from ART about rhel-8 and golang-1.15 not being optional, went to run locally, and found the path issue.