### PR TITLE
Bug 1898531: Tests: Adjust ptp configuration in case of ipv6 only interfaces.

### DIFF
--- a/test/ptp/ptp.go
+++ b/test/ptp/ptp.go
@@ -330,7 +330,7 @@ func configurePTP() {
 			By("Creating the policy for the grandmaster node")
 			err = createConfig(PtpGrandMasterPolicyName,
 				gmInterface,
-				"",
+				"-2",
 				"-a -r -r",
 				PtpGrandmasterNodeLabel,
 				pointer.Int64Ptr(5))
@@ -339,7 +339,7 @@ func configurePTP() {
 			By("Creating the policy for the slave node")
 			err = createConfig(PtpSlavePolicyName,
 				slaveInterface,
-				"-s",
+				"-s -2",
 				"-a -r",
 				PtpSlaveNodeLabel,
 				pointer.Int64Ptr(5))


### PR DESCRIPTION
When checking for available interfaces, we use the default for ptp4l, which is ipv4.
Here, we check if a given interface has ipv6 only addresses, and in case we add the -6 parameter
to ptp4l.

