### PR TITLE
Update ptp-daemon.yaml to expose the UDS socket

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -66,6 +66,8 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/linuxptp
+        - name: socket-dir
+          mountPath: /var/run
       volumes:
         - name: config-volume
           configMap:
@@ -73,6 +75,10 @@ spec:
         - name: linuxptp-certs
           secret:
             secretName: linuxptp-daemon-secret
+        - name: socket-dir
+          hostPath:
+            path: /var/run/ptp
+            type: DirectoryOrCreate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
Updates to bindata/ptp-daemon.yaml to expose the UDS socket from /var/run inside the container into host path /var/run/ptp so it can be access by applications running in the node requiring to interact with ptp4l for tracking PTP time synchronization