### PR TITLE
Bug 1931030: Change must-gather/Dockerfile.rhel7 to use must-gather image

### DIFF
--- a/must-gather/Dockerfile.rhel7
+++ b/must-gather/Dockerfile.rhel7
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS b
 WORKDIR /go/src/github.com/openshift/ptp-operator/must-gather
 COPY . .
 
-FROM registry.ci.openshift.org/ocp/4.8:base
+FROM registry.ci.openshift.org/ocp/4.8:must-gather
 LABEL io.k8s.display-name="ptp-operator-must-gather" \
       io.k8s.description="This is a PTP must-gather image that collectes PTP operator related resources."
 COPY --from=builder /go/src/github.com/openshift/ptp-operator/must-gather/collection-scripts/* /usr/bin/


### PR DESCRIPTION
This should fix the problem of oc adm must-gather not finding oc binary