### PR TITLE
add host root directory access for chroot purpose

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -68,6 +68,8 @@ spec:
           mountPath: /etc/linuxptp
         - name: socket-dir
           mountPath: /var/run
+        - name: host
+          mountPath: /host
       volumes:
         - name: config-volume
           configMap:
@@ -79,6 +81,9 @@ spec:
           hostPath:
             path: /var/run/ptp
             type: DirectoryOrCreate
+        - name: host
+          hostPath:
+            path: /
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
This is necessary due to https://github.com/openshift/linuxptp-daemon/pull/37 

In order to be able to do systemctl from inside the ptp-daemon container, chroot is required.