### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -14,6 +14,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: linuxptp-daemon
     spec:

--- a/manifests/4.8/ptp-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/ptp-operator.v4.8.0.clusterserviceversion.yaml
@@ -107,6 +107,8 @@ spec:
       kind: Namespace
       metadata:
         name: openshift-ptp
+        annotations:
+          workload.openshift.io/allowed: "management"
         labels:
           name: openshift-ptp
           openshift.io/cluster-monitoring: "true"
@@ -208,6 +210,8 @@ spec:
               name: ptp-operator
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: ptp-operator
             spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.