### PR TITLE
PTP Tests: check ethtool capability only

### DIFF
--- a/test/ptp/ptp.go
+++ b/test/ptp/ptp.go
@@ -530,13 +530,13 @@ func isPTPEnabled(ethToolOutput *bytes.Buffer) bool {
 		line := strings.TrimPrefix(scanner.Text(), "\t")
 		parts := strings.Fields(line)
 		if parts[0] == ETHTOOL_HARDWARE_RECEIVE_CAP {
-			RxEnabled = parts[1] == ETHTOOL_RX_HARDWARE_FLAG
+			RxEnabled = true
 		}
 		if parts[0] == ETHTOOL_HARDWARE_TRANSMIT_CAP {
-			TxEnabled = parts[1] == ETHTOOL_TX_HARDWARE_FLAG
+			TxEnabled = true
 		}
 		if parts[0] == ETHTOOL_HARDWARE_RAW_CLOCK_CAP {
-			RawEnabled = parts[1] == ETHTOOL_RAW_HARDWARE_FLAG
+			RawEnabled = true
 		}
 	}
 	return RxEnabled && TxEnabled && RawEnabled


### PR DESCRIPTION
Some devices only output the capability (like hardware-receive)
without specifying the type (HW or SW). In this case we treat the row as
not existing.

Sample output:
ethtool -T ens3f1
Time stamping parameters for ens3f1:
Capabilities:
	hardware-transmit
	software-transmit
	hardware-receive
	software-receive
	software-system-clock
	hardware-raw-clock

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>