### PR TITLE
Add OLM bug workaround for workload partitioning

### DIFF
--- a/manifests/4.8/ptp-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/ptp-operator.v4.8.0.clusterserviceversion.yaml
@@ -8,6 +8,10 @@ metadata:
     categories: Networking
     provider: Red Hat
     support: Red Hat
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     containerImage: quay.io/openshift/origin-ptp-operator:4.8
     createdAt: 2019-10-14
     certified: "false"


### PR DESCRIPTION
PR https://github.com/openshift/ptp-operator/pull/106 added annotations
required for supporting the workload partitioning feature for ocp 4.8.
However, OLM has a bug in processing the annotations (BZ 1950047).
This PR provides a workaround necessary to release the workload
partitioning in OCP 4.8.