### PR TITLE
Fix setting CGO_ENABLED in build

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -6,6 +6,7 @@ REPO=github.com/openshift/ptp-operator
 WHAT=${WHAT:-manager}
 GOFLAGS=${GOFLAGS:-}
 GLDFLAGS=${GLDFLAGS:-}
+CGO_ENABLED=${CGO_ENABLED:-1}
 
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
@@ -23,8 +24,6 @@ GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
 export BIN_PATH=build/_output/bin/
 export BIN_NAME=ptp-operator
 mkdir -p ${BIN_PATH}
-
-CGO_ENABLED=1
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE})"
 CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${BIN_NAME} ${REPO}/cmd/${WHAT}


### PR DESCRIPTION
Using CGO_ENABLED to allow building on fedora 34.  Not currently able to pass it in, and need to modify this build script if I want to override.