### PR TITLE
Bump .ci-operator golang version

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.12
+  tag: golang-1.15


### PR DESCRIPTION
CI fails to compile tests since 1.12 is too old

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>