### PR TITLE
Bug 1987136: Declare supported arches in CSV

### DIFF
--- a/manifests/4.6/ptp-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/ptp-operator.v4.6.0.clusterserviceversion.yaml
@@ -3,6 +3,8 @@ kind: ClusterServiceVersion
 metadata:
   name: ptp-operator.v4.6.0
   namespace: openshift-ptp
+  labels:
+    operatorframework.io/arch.amd64: supported
   annotations:
     capabilities: Basic Install
     categories: Networking

--- a/manifests/4.7/ptp-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/ptp-operator.v4.7.0.clusterserviceversion.yaml
@@ -3,6 +3,8 @@ kind: ClusterServiceVersion
 metadata:
   name: ptp-operator.v4.7.0
   namespace: openshift-ptp
+  labels:
+    operatorframework.io/arch.amd64: supported
   annotations:
     capabilities: Basic Install
     categories: Networking

--- a/manifests/4.8/ptp-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/ptp-operator.v4.8.0.clusterserviceversion.yaml
@@ -3,6 +3,8 @@ kind: ClusterServiceVersion
 metadata:
   name: ptp-operator.v4.8.0
   namespace: openshift-ptp
+  labels:
+    operatorframework.io/arch.amd64: supported
   annotations:
     capabilities: Basic Install
     categories: Networking

--- a/manifests/4.9/ptp-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/ptp-operator.v4.9.0.clusterserviceversion.yaml
@@ -3,6 +3,8 @@ kind: ClusterServiceVersion
 metadata:
   name: ptp-operator.v4.9.0
   namespace: openshift-ptp
+  labels:
+    operatorframework.io/arch.amd64: supported
   annotations:
     capabilities: Basic Install
     categories: Networking


### PR DESCRIPTION
The OperatorHub currently assumes x86-only for any operators which do
not declare any such labels.  Declaring these explicitly should make the
current status more obvious in the code, and make it easier to correctly
add further architectures when conditions warrant.
