### PR TITLE
Bug 1991206: Add disconnected infrastructure-feature

### DIFF
--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -66,6 +66,7 @@ metadata:
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
     olm.skipRange: '>=4.3.0-0 <4.9.0'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -61,6 +61,7 @@ metadata:
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
     olm.skipRange: '>=4.3.0-0 <4.9.0'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     provider: Red Hat
     repository: https://github.com/openshift/ptp-operator
     support: Red Hat

--- a/manifests/4.9/ptp-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/ptp-operator.v4.9.0.clusterserviceversion.yaml
@@ -12,6 +12,7 @@ metadata:
     # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
     # TODO: remove the next line after BZ-1950047 is resolved.
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     containerImage: quay.io/openshift/origin-ptp-operator:4.9
     createdAt: 2019-10-14
     certified: "false"


### PR DESCRIPTION
This commit add the needed label to inform OLM that the ptp-operator
support to be installed in a disconnected environment

Signed-off-by: Sebastian Sch <sebassch@gmail.com>