### PR TITLE
Bug 1993854: Added /var/run volume for sidecar

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -46,6 +46,8 @@ spec:
               mountPath: /store
             - name: event-bus-socket
               mountPath: /cloud-native
+            - name: socket-dir
+              mountPath: /var/run
           ports:
             - name: metrics-port
               containerPort: 9091


### PR DESCRIPTION
This PR adds /var/run volume  for cloud-event-proxy sidecar  for event management.
The new multi-interface changes to  Linux-ptp-daemon and  cloud-event-proxy , requires cloud-event-proxy to watch for ptp4l.X.config file updates read interface details.
