### PR TITLE
Bug 1999886:fixed bind address issue

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -38,7 +38,7 @@ spec:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
             - "--transport-host={{ .EventTransportHost }}"
-            - "--api-port=8080"
+            - "--api-port=8089"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/linuxptp


### PR DESCRIPTION
Sidecar API was configured to listen to 8080, although sidecar was designed  to run with hostnetwork=false, but ptp-operator requires hostNetwork set to true , hence 8080 was giving bind address already in use.
Changed port to 8089 to avoid any address in use error. 