### PR TITLE
add host ip env

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -58,6 +58,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
         {{ end }}
         - name: kube-rbac-proxy
           image: {{.KubeRbacProxy}}


### PR DESCRIPTION
Event side car needs to know host _ip to construct amqp transport that was created as nodeport service
access as amq://nodeip:port
This PR passes node_ip to the event sidecar 

