### PR TITLE
Bug 2005415: PTP operator with sidecar api configured throws bind: address already in use 

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -38,7 +38,7 @@ spec:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
             - "--transport-host={{ .EventTransportHost }}"
-            - "--api-port=8089"
+            - "--api-port=9085"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/linuxptp
@@ -51,6 +51,8 @@ spec:
           ports:
             - name: metrics-port
               containerPort: 9091
+            - name: api-port
+              containerPort: 9085
           env:
             - name: PTP_PLUGIN
               value: "true"


### PR DESCRIPTION
This happens in one of the VM's running master node.  Colliding with ironic port 8089 is in use.
sh-4.4# ss -anp | grep 8089
tcp   LISTEN    0      128                         :8089                   *:        users:(("ironic-conducto",pid=33074,fd=7),("ironic-conducto",pid=33074,fd=6))

This Fix changes port to 9085
Once this is fixed, cherry pick to release-4.9  branch 