### PR TITLE
Bug 2005926: Prometheus rules to use new metrics 

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -228,7 +228,7 @@ spec:
               severity: warning
         {{ end }}
         {{ if (eq .EnableEventPublisher false) }}
-        - alert: NodeOutOfPtpSync
+        - alert: HighPtpSyncOffset
           annotations:
             message: |
               All nodes should have ptp sync offset lower then 100

--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -218,14 +218,14 @@ spec:
       rules:
         {{ if (eq .EnableEventPublisher true) }}
         - alert: NodeOutOfPtpSync
-            annotations:
-              message: |
-                {{ "{{" }} $labels.iface }} is not in sync
-            expr: |
-              openshift_ptp_clock_state != 1
-            for: 2m
-            labels:
-              severity: warning
+          annotations:
+            message: |
+              {{ "{{" }} $labels.iface }} is not in sync
+          expr: |
+            openshift_ptp_clock_state != 1
+          for: 2m
+          labels:
+            severity: warning
         {{ end }}
         {{ if (eq .EnableEventPublisher false) }}
         - alert: HighPtpSyncOffset

--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -216,6 +216,18 @@ spec:
   groups:
     - name: ptp.rules
       rules:
+        {{ if (eq .EnableEventPublisher true) }}
+        - alert: NodeOutOfPtpSync
+            annotations:
+              message: |
+                {{ $labels.iface }} is not in sync
+            expr: |
+              openshift_ptp_clock_state != 1
+            for: 2m
+            labels:
+              severity: warning
+        {{ end }}
+        {{ if (eq .EnableEventPublisher false) }}
         - alert: NodeOutOfPtpSync
           annotations:
             message: |
@@ -225,3 +237,4 @@ spec:
           for: 2m
           labels:
             severity: warning
+        {{ end }}

--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -220,7 +220,7 @@ spec:
         - alert: NodeOutOfPtpSync
             annotations:
               message: |
-                {{ $labels.iface }} is not in sync
+                {{ "{{" }} $labels.iface }} is not in sync
             expr: |
               openshift_ptp_clock_state != 1
             for: 2m


### PR DESCRIPTION
For fast event m we have clock sync state metrics to notify if the node is our of sync .
This PR uses openshift_ptp_clock_state (when 1 !=LOCKED)  to define Prometheus rule to fire an Alert .

