### PR TITLE
Add 'rhel8' suffix to cloud-event-proxy references to match comet repository name

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -15,7 +15,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kube-rbac-proxy:4.10
-  - name: cloud-event-proxy
+  - name: cloud-event-proxy-rhel8
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cloud-event-proxy:4.10


### PR DESCRIPTION
Changes in this PR:

    - update the image name in image references.
    - update the container name in linux PTP Daemon Daemon set CR.

Signed-off-by: Nishant Parekh <nparekh@redhat.com>