### PR TITLE
Add ptp scheduling to PtpProfile crd

### DIFF
--- a/api/v1/ptpconfig_types.go
+++ b/api/v1/ptpconfig_types.go
@@ -61,12 +61,14 @@ type PtpConfigList struct {
 }
 
 type PtpProfile struct {
-	Name              *string            `json:"name"`
-	Interface         *string            `json:"interface,omitempty"`
-	Ptp4lOpts         *string            `json:"ptp4lOpts,omitempty"`
-	Phc2sysOpts       *string            `json:"phc2sysOpts,omitempty"`
-	Ptp4lConf         *string            `json:"ptp4lConf,omitempty"`
-	PtpClockThreshold *PtpClockThreshold `json:"ptpClockThreshold,omitempty"`
+	Name                  *string            `json:"name"`
+	Interface             *string            `json:"interface,omitempty"`
+	Ptp4lOpts             *string            `json:"ptp4lOpts,omitempty"`
+	Phc2sysOpts           *string            `json:"phc2sysOpts,omitempty"`
+	Ptp4lConf             *string            `json:"ptp4lConf,omitempty"`
+	PtpSchedulingPolicy   *string            `json:"ptpSchedulingPolicy,omitempty"`
+	PtpSchedulingPriority *int64             `json:"ptpSchedulingPriority,omitempty"`
+	PtpClockThreshold     *PtpClockThreshold `json:"ptpClockThreshold,omitempty"`
 }
 
 type PtpClockThreshold struct {

--- a/bundle/manifests/ptp.openshift.io_ptpconfigs.yaml
+++ b/bundle/manifests/ptp.openshift.io_ptpconfigs.yaml
@@ -65,6 +65,11 @@ spec:
                           format: int64
                           type: integer
                       type: object
+                    ptpSchedulingPolicy:
+                      type: string
+                    ptpSchedulingPriority:
+                      format: int64
+                      type: integer
                   required:
                   - name
                   type: object

--- a/config/crd/bases/ptp.openshift.io_ptpconfigs.yaml
+++ b/config/crd/bases/ptp.openshift.io_ptpconfigs.yaml
@@ -67,6 +67,11 @@ spec:
                           format: int64
                           type: integer
                       type: object
+                    ptpSchedulingPolicy:
+                      type: string
+                    ptpSchedulingPriority:
+                      format: int64
+                      type: integer
                   required:
                   - name
                   type: object

--- a/controllers/recommend.go
+++ b/controllers/recommend.go
@@ -10,9 +10,18 @@ import (
 	ptpv1 "github.com/openshift/ptp-operator/api/v1"
 )
 
-func printWhenNotNil(p *string, description string) {
-	if p != nil {
-		glog.Info(description, ": ", *p)
+func printWhenNotNil(p interface{}, description string) {
+	switch v := p.(type) {
+	case *string:
+		if v != nil {
+			glog.Info(description, ": ", *v)
+		}
+	case *int64:
+		if v != nil {
+			glog.Info(description, ": ", *v)
+		}
+	default:
+		glog.Info(description, ": ", v)
 	}
 }
 
@@ -33,6 +42,8 @@ func getRecommendNodePtpProfiles(ptpConfigList *ptpv1.PtpConfigList, node corev1
 		printWhenNotNil(profile.Ptp4lOpts, "Ptp4lOpts")
 		printWhenNotNil(profile.Phc2sysOpts, "Phc2sysOpts")
 		printWhenNotNil(profile.Ptp4lConf, "Ptp4lConf")
+		printWhenNotNil(profile.PtpSchedulingPolicy, "PtpSchedulingPolicy")
+		printWhenNotNil(profile.PtpSchedulingPriority, "PtpSchedulingPriority")
 		glog.Infof("------------------------------------")
 	}
 

--- a/manifests/stable/ptp.openshift.io_ptpconfigs.yaml
+++ b/manifests/stable/ptp.openshift.io_ptpconfigs.yaml
@@ -65,6 +65,11 @@ spec:
                           format: int64
                           type: integer
                       type: object
+                    ptpSchedulingPolicy:
+                      type: string
+                    ptpSchedulingPriority:
+                      format: int64
+                      type: integer
                   required:
                   - name
                   type: object


### PR DESCRIPTION
Add PtpSchedulingPolicy and PtpSchedulingPriority to PtpProfile crd.
These will be used to allow running ptp4l and phc2sys with custom
priority (e.g. SCHED_FIFO).