### PR TITLE
Bug 2019198:Rename Prometheus metrics in alert rules

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -233,7 +233,7 @@ spec:
             message: |
               All nodes should have ptp sync offset lower then 100
           expr: |
-            openshift_ptp_max_offset_from_master > 100 or openshift_ptp_max_offset_from_master < -100
+            openshift_ptp_offset_ns > 100 or openshift_ptp_offset_ns < -100
           for: 2m
           labels:
             severity: warning

--- a/test/conformance/ptp/ptp.go
+++ b/test/conformance/ptp/ptp.go
@@ -356,7 +356,7 @@ var _ = Describe("[ptp]", func() {
 						Eventually(func() string {
 							buf, _ := pods.ExecCommand(client.Client, pod, PtpContainerName, []string{"curl", "127.0.0.1:9091/metrics"})
 							return buf.String()
-						}, 5*time.Minute, 5*time.Second).Should(ContainSubstring("openshift_ptp_max_offset_from_master"),
+						}, 5*time.Minute, 5*time.Second).Should(ContainSubstring("openshift_ptp_offset_ns"),
 							fmt.Sprint("Time metrics are not detected"))
 						slavePodDetected = true
 						break


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
Depends on https://github.com/openshift/linuxptp-daemon/pull/58
Address the Bug, fixes renaming of offset metrics. Once the above linuxptp-daemon is merged, this PR fixed the alert rules naming