### PR TITLE
Add ptp unit test for events

### DIFF
--- a/test/utils/consts.go
+++ b/test/utils/consts.go
@@ -20,6 +20,7 @@ const (
 	NodePtpDeviceAPIPath            = "/apis/ptp.openshift.io/v1/namespaces/openshift-ptp/nodeptpdevices/"
 	ConfigPtpAPIPath                = "/apis/ptp.openshift.io/v1/namespaces/openshift-ptp/ptpconfigs"
 	PtpContainerName                = "linuxptp-daemon-container"
+	EventProxyContainerName         = "cloud-event-proxy"
 )
 
 const (

--- a/test/utils/event/event.go
+++ b/test/utils/event/event.go
@@ -1,0 +1,12 @@
+package event
+
+import (
+	"os"
+	"strconv"
+)
+
+// Enabled event if ptp event is required
+func Enable() bool {
+	eventMode, _ := strconv.ParseBool(os.Getenv("ENABLE_PTP_EVENT"))
+	return eventMode
+}


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
Adds following unit test for testing PTP event
1. Enable ptp event by setting env variable ENABLE_PTP_EVENT
2. Verifies by checking the following 
  - Checking event side car is present
  - Checking event metrics are present
  - Checking  event api is healthy
  - Checking events are generated
  


