### PR TITLE
Make context-use more consistent

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func createDefaultOperatorConfig(cfg *rest.Config) error {
 			DaemonNodeSelector: map[string]string{},
 		},
 	}
-	err = c.Get(context.TODO(), types.NamespacedName{
+	err = c.Get(context.Background(), types.NamespacedName{
 		Name: names.DefaultOperatorConfigName, Namespace: names.Namespace}, config)
 
 	if err != nil {
@@ -138,7 +138,7 @@ func createDefaultOperatorConfig(cfg *rest.Config) error {
 			logger.Info("Create default OperatorConfig")
 			config.Namespace = names.Namespace
 			config.Name = names.DefaultOperatorConfigName
-			err = c.Create(context.TODO(), config)
+			err = c.Create(context.Background(), config)
 			if err != nil {
 				return err
 			}

--- a/test/validation/tests/validation.go
+++ b/test/validation/tests/validation.go
@@ -44,13 +44,13 @@ var _ = Describe("validation", func() {
 
 		It("should have the ptp CRDs available in the cluster", func() {
 			crd := &apiext.CustomResourceDefinition{}
-			err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: testutils.NodePtpDevicesCRD}, crd)
+			err := testclient.Client.Get(context.Background(), goclient.ObjectKey{Name: testutils.NodePtpDevicesCRD}, crd)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: testutils.PtpConfigsCRD}, crd)
+			err = testclient.Client.Get(context.Background(), goclient.ObjectKey{Name: testutils.PtpConfigsCRD}, crd)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: testutils.PtpOperatorConfigsCRD}, crd)
+			err = testclient.Client.Get(context.Background(), goclient.ObjectKey{Name: testutils.PtpOperatorConfigsCRD}, crd)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
context.TODO() and context.Background() are the same thing however they were not consistently being used.

Prior to this change, `Background()` had 60 uses and `TODO()` had 5 uses so I made every reference use context.Background().