### PR TITLE
bugfix in ptpconfig discovery,  fix for logging and additional logs

### DIFF
--- a/api/v1/ptpconfig_webhook.go
+++ b/api/v1/ptpconfig_webhook.go
@@ -170,7 +170,9 @@ func GetInterfaces(config PtpConfig, mode PtpRole) (interfaces []string) {
 	var finalInterfaces []string
 	for _, aIf := range interfaces {
 		if aIf == "global" {
-			finalInterfaces = append(finalInterfaces, *config.Spec.Profile[0].Interface)
+			if config.Spec.Profile[0].Interface != nil {
+				finalInterfaces = append(finalInterfaces, *config.Spec.Profile[0].Interface)
+			}
 		} else {
 			finalInterfaces = append(finalInterfaces, aIf)
 		}

--- a/test/conformance/ptp/ptp.go
+++ b/test/conformance/ptp/ptp.go
@@ -172,7 +172,7 @@ var _ = Describe("[ptp]", func() {
 			})
 		})
 
-		XContext("PTP Interfaces discovery", func() {
+		Context("PTP Interfaces discovery", func() {
 
 			BeforeEach(func() {
 				if fullConfig.Status == testconfig.DiscoveryFailureStatus {
@@ -207,6 +207,46 @@ var _ = Describe("[ptp]", func() {
 					}
 				}
 			})
+
+			It("Should retrieve the details of hardwares for the Ptp", func() {
+				By("Getting the version of the OCP cluster")
+
+				ocpVersion, err := getOCPVersion()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ocpVersion).ShouldNot(BeEmpty())
+
+				By("Getting the version of the PTP operator")
+
+				ptpOperatorVersion, err := getPtpOperatorVersion()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ptpOperatorVersion).ShouldNot(BeEmpty())
+
+				By("Getting the NIC details of all the PTP enabled interfaces")
+
+				var mapping = make(map[string]string)
+				for _, pod := range ptpRunningPods {
+					mapping = getNICInfo(pod)
+					Expect(mapping).ShouldNot(BeEmpty())
+				}
+
+				By("Getting the interface details of the PTP config")
+
+				ptpConfig := testconfig.GlobalConfig
+				if ptpConfig.DiscoveredGrandMasterPtpConfig != nil {
+					printInterface(ptpv1.PtpConfig(*ptpConfig.DiscoveredGrandMasterPtpConfig), mapping)
+				}
+				if ptpConfig.DiscoveredClockUnderTestPtpConfig != nil {
+					printInterface(ptpv1.PtpConfig(*ptpConfig.DiscoveredClockUnderTestPtpConfig), mapping)
+				}
+				if ptpConfig.DiscoveredClockUnderTestSecondaryPtpConfig != nil {
+					printInterface(ptpv1.PtpConfig(*ptpConfig.DiscoveredClockUnderTestSecondaryPtpConfig), mapping)
+				}
+
+				By("Getting ptp config details")
+
+				logrus.Infof("Discovered master ptp config %s", ptpConfig.DiscoveredGrandMasterPtpConfig.String())
+				logrus.Infof("Discovered slave ptp config %s", ptpConfig.DiscoveredClockUnderTestPtpConfig.String())
+			})
 		})
 		Context("PTP ClockSync", func() {
 			err := metrics.InitEnvIntParamConfig("MAX_OFFSET_IN_NS", metrics.MaxOffsetDefaultNs, &metrics.MaxOffsetNs)
@@ -215,6 +255,10 @@ var _ = Describe("[ptp]", func() {
 
 			// 25733
 			It("PTP daemon apply match rule based on nodeLabel", func() {
+
+				if fullConfig.PtpModeDesired == testconfig.Discovery {
+					Skip(fmt.Sprint("This test needs the ptp-daemon to be rebooted but it is not possible in discovery mode, skipping"))
+				}
 				profileSlave := fmt.Sprintf("Profile Name: %s", fullConfig.DiscoveredClockUnderTestPtpConfig.Name)
 				profileMaster := ""
 				if fullConfig.DiscoveredGrandMasterPtpConfig != nil {
@@ -306,7 +350,7 @@ var _ = Describe("[ptp]", func() {
 					Skip("cannot determine if cluster is single node")
 				}
 				if fullConfig.PtpModeDesired == testconfig.Discovery {
-					Skip("Skipping because adding a different profile")
+					Skip("Skipping because adding a different profile and no modifications are allowed in discovery mode")
 				}
 				var policyName string
 				var modifiedPtpConfig *ptpv1.PtpConfig

--- a/test/conformance/test_suite_test.go
+++ b/test/conformance/test_suite_test.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/openshift/ptp-operator/test/conformance/ptp"
 	"github.com/openshift/ptp-operator/test/utils/clean"
 	testclient "github.com/openshift/ptp-operator/test/utils/client"
+	"github.com/openshift/ptp-operator/test/utils/testconfig"
 )
 
 // TODO: we should refactor tests to use client from controller-runtime package
@@ -53,7 +54,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	if DeletePtpConfig {
+
+	if DeletePtpConfig && testconfig.GetDesiredConfig(false).PtpModeDesired != testconfig.Discovery {
 		clean.All()
 	}
 })

--- a/test/utils/metrics/metrics.go
+++ b/test/utils/metrics/metrics.go
@@ -90,9 +90,9 @@ func getMetric(nodeName, aIf, metricName string) (metric string, err error) {
 		var regex string
 		if metricName == OpenshiftPtpOffsetNs {
 			aIf = aIf[:len(aIf)-1] + "x"
-			regex = metricName + `{` + fromMaster + `iface="` + aIf + `",node="` + ptpPods.Items[index].Spec.NodeName + `",process="ptp4l"} ([0-9]*)`
+			regex = metricName + `{` + fromMaster + `iface="` + aIf + `",node="` + ptpPods.Items[index].Spec.NodeName + `",process="ptp4l"} (-*[0-9]*)`
 		} else {
-			regex = metricName + `{iface="` + aIf + `",node="` + ptpPods.Items[index].Spec.NodeName + `",process="ptp4l"} ([0-9]*)`
+			regex = metricName + `{iface="` + aIf + `",node="` + ptpPods.Items[index].Spec.NodeName + `",process="ptp4l"} (-*[0-9]*)`
 		}
 		r := regexp.MustCompile(regex)
 		for _, submatches := range r.FindAllStringSubmatchIndex(metrics, -1) {
@@ -131,6 +131,12 @@ func CheckClockRoleAndOffset(ptpConfig *ptpv1.PtpConfig, label, nodeName *string
 	if nodeName == nil {
 		var name string
 		name, err = getNode(*label)
+		if err != nil || name == "" || label == nil || *label != utils.PtpClockUnderTestNodeLabel {
+			fmt.Printf(`error getting node name for label %s
+Did you label the node running the clock under test with the %s label?
+Only this label should be used to identify the clock under test. err:%s`, *label, utils.PtpClockUnderTestNodeLabel, err)
+			os.Exit(1)
+		}
 		nodeName = &name
 	}
 	masterIfs := ptpv1.GetInterfaces(*ptpConfig, ptpv1.Master)
@@ -143,7 +149,7 @@ func CheckClockRoleAndOffset(ptpConfig *ptpv1.PtpConfig, label, nodeName *string
 		}
 		roleInt, err := strconv.Atoi(role)
 		if err != nil {
-			return fmt.Errorf("error strconv err:%s", err)
+			return fmt.Errorf("error strconv for role=%s, err:%s", role, err)
 		}
 		logrus.Infof("nodeName=%s, aIf=%s, roleInt=%s", *nodeName, aIf, MetricRole(roleInt))
 
@@ -162,11 +168,11 @@ func CheckClockRoleAndOffset(ptpConfig *ptpv1.PtpConfig, label, nodeName *string
 		}
 		roleInt, err := strconv.Atoi(roleString)
 		if err != nil {
-			return fmt.Errorf("error strconv err:%s", err)
+			return fmt.Errorf("error strconv for roleString=%s, err:%s", roleString, err)
 		}
 		offsetInt, err := strconv.Atoi(offsetString)
 		if err != nil {
-			return fmt.Errorf("error strconv err:%s", err)
+			return fmt.Errorf("error strconv for offsetString=%s, err:%s", offsetString, err)
 		}
 		logrus.Infof("nodeName=%s, aIf=%s, offsetInt=%d ns, roleInt=%s", *nodeName, aIf, offsetInt, MetricRole(roleInt))
 		if MetricRole(roleInt) != MetricRoleSlave {

--- a/test/utils/pods/pods.go
+++ b/test/utils/pods/pods.go
@@ -88,9 +88,10 @@ func HasPodLabelOrNodeName(pod *corev1.Pod, label, nodeName *string) (result boo
 	if label == nil && nodeName == nil {
 		return result, fmt.Errorf("label and nodeName are nil")
 	}
-	if label != nil && nodeName != nil {
+	// node name might be present and will be superseded by label
+	/*if label != nil && nodeName != nil {
 		return result, fmt.Errorf("label or nodeName must be nil")
-	}
+	}*/
 	if label != nil {
 		result, err = PodRole(pod, *label)
 		if err != nil {


### PR DESCRIPTION
Some bugfxes in ptpconfig discovery, logging, adding additional logs
also includes https://github.com/openshift/ptp-operator/pull/227 and skipping test old test waiting for clock ID when in discovery mode
