### PR TITLE
Bug OCPBUGS-1478: [release-4.11]update reference to ptp operator image from 4.10 to 4.11

### DIFF
--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -60,7 +60,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-ptp-operator:4.10
+    containerImage: quay.io/openshift/origin-ptp-operator:4.11
     createdAt: "2019-10-14"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-ptp-operator:4.10
+    containerImage: quay.io/openshift/origin-ptp-operator:4.11
     createdAt: "2019-10-14"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures

--- a/hack/env.sh
+++ b/hack/env.sh
@@ -2,7 +2,7 @@ REPO_DIR="$(dirname $0)/.."
 NAMESPACE=openshift-ptp
 OPERATOR_EXEC=oc
 
-export RELEASE_VERSION=v4.10.0
+export RELEASE_VERSION=v4.11.0
 export IMAGE_TAG=latest
 export OPERATOR_NAME=ptp-operator
 

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -60,7 +60,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-ptp-operator:4.10
+    containerImage: quay.io/openshift/origin-ptp-operator:4.11
     createdAt: "2019-10-14"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures


### PR DESCRIPTION
csv for 4.11 had reference to 4.10 .
Fixed to point to  4.11
