### PR TITLE
Add labels to fix pod-security issue in 4.12

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,10 @@ kind: Namespace
 metadata:
   name: openshift-ptp
   labels:
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"
     name: openshift-ptp
     openshift.io/cluster-monitoring: "true"
 ---


### PR DESCRIPTION
This is temporary fix, until OLM fix gets merged into 4.12 