### PR TITLE
Fix skipRange with double quotes

### DIFF
--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -65,7 +65,7 @@ metadata:
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
-    olm.skipRange: '>=4.3.0-0 <4.12.0'
+    olm.skipRange: ">=4.3.0-0 <4.12.0"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.22.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -60,7 +60,7 @@ metadata:
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
-    olm.skipRange: '>=4.3.0-0 <4.12.0'
+    olm.skipRange: ">=4.3.0-0 <4.12.0"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     provider: Red Hat
     repository: https://github.com/openshift/ptp-operator

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -65,7 +65,7 @@ metadata:
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
-    olm.skipRange: '>=4.3.0-0 <4.12.0'
+    olm.skipRange: ">=4.3.0-0 <4.12.0"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.22.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
When ART builds the bundle image the skipRange regexp should exactly
match expected regexp in art.yaml. Currently the upper bound of skipRange
is not auto-updating because we use single quote in the skipRange string.

Signed-off-by: Jack Ding <jackding@gmail.com>