### PR TITLE
Added ptp hw details to junit system-out

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/test-network-function/graphsolver-lib v0.0.0-20220923194309-2492312b0d54
 	github.com/test-network-function/l2discovery-lib v0.0.0-20221017141500-ab5454f9e565
-	github.com/test-network-function/privileged-daemonset v0.0.0-20221007131241-54f0523bd810
+	github.com/test-network-function/privileged-daemonset v0.0.1
 	k8s.io/api v0.25.3
 	k8s.io/apiextensions-apiserver v0.25.2
 	k8s.io/apimachinery v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,8 @@ github.com/test-network-function/l2discovery-lib v0.0.0-20221017141500-ab5454f9e
 github.com/test-network-function/l2discovery-lib v0.0.0-20221017141500-ab5454f9e565/go.mod h1:9097jN5R2Q1nZfLK9+ccs1VwtNHuG5E/qbslrou8MnY=
 github.com/test-network-function/privileged-daemonset v0.0.0-20221007131241-54f0523bd810 h1:fKEfoo3Ld/F30ACZRLg2TDN6C9ChtKLqrskG4NIcGnU=
 github.com/test-network-function/privileged-daemonset v0.0.0-20221007131241-54f0523bd810/go.mod h1:CuyN/5N/yKavCQ8Ba0K52Mv/YbtVSN4Snk5tBaLJR68=
+github.com/test-network-function/privileged-daemonset v0.0.1 h1:rkUULsr1lcw2dPhAOzNusVQ/O8fCLxA6fTr/YLmGl08=
+github.com/test-network-function/privileged-daemonset v0.0.1/go.mod h1:c5m+hDVcPkn+pMYUNqGhB8N2ezc1mtxTOt/e7PCU94A=
 github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869 h1:7v7L5lsfw4w8iqBBXETukHo4IPltmD+mWoLRYUmeGN8=
 github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869/go.mod h1:Rfzr+sqaDreiCaoQbFCu3sTXxeFq/9kXRuyOoSlGQHE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/test/conformance/ptp/ptp.go
+++ b/test/conformance/ptp/ptp.go
@@ -26,9 +26,13 @@ import (
 
 	"github.com/openshift/ptp-operator/test/pkg/client"
 	"github.com/openshift/ptp-operator/test/pkg/execute"
+
 	"github.com/openshift/ptp-operator/test/pkg/nodes"
 	"github.com/openshift/ptp-operator/test/pkg/pods"
 	"github.com/openshift/ptp-operator/test/pkg/testconfig"
+
+	// TODO: Remove this ginkgo_reporter import when ginkgo is updated to v2.
+	ptpReporter "github.com/openshift/ptp-operator/test/pkg/ginkgo_reporter"
 )
 
 type TestCase string
@@ -205,13 +209,27 @@ var _ = Describe("[ptp]", func() {
 				ptpInterfacesList := fullConfig.L2Config.GetPtpIfList()
 
 				for _, ptpInterface := range ptpInterfacesList {
-					logrus.Infof("Interface Name: %s, Device: %s, Function: %s, Description: %s", ptpInterface.IfName, ptpInterface.IfPci.Device, ptpInterface.IfPci.Function, ptpInterface.IfPci.Description)
+					ifaceHwDetails := fmt.Sprintf("Device: %s, Function: %s, Description: %s",
+						ptpInterface.IfPci.Device, ptpInterface.IfPci.Function, ptpInterface.IfPci.Description)
+
+					logrus.Infof("Node: %s, Interface Name: %s, %s", ptpInterface.NodeName, ptpInterface.IfName, ifaceHwDetails)
+
+					// TODO: Remove "ptpReporter." prefix when this project is migrated to ginkgo v2.
+					ptpReporter.AddReportEntry(fmt.Sprintf("Node %s, Interface: %s", ptpInterface.NodeName, ptpInterface.IfName), ifaceHwDetails)
 				}
 
 				By("Getting ptp config details")
 				ptpConfig := testconfig.GlobalConfig
-				logrus.Infof("Discovered master ptp config %s", ptpConfig.DiscoveredGrandMasterPtpConfig.String())
-				logrus.Infof("Discovered slave ptp config %s", ptpConfig.DiscoveredClockUnderTestPtpConfig.String())
+
+				masterPtpConfigStr := ptpConfig.DiscoveredGrandMasterPtpConfig.String()
+				slavePtpConfigStr := ptpConfig.DiscoveredClockUnderTestPtpConfig.String()
+
+				logrus.Infof("Discovered master ptp config %s", masterPtpConfigStr)
+				logrus.Infof("Discovered slave ptp config %s", slavePtpConfigStr)
+
+				// TODO: Remove "ptpReporter." prefix when this project is migrated to ginkgo v2.
+				ptpReporter.AddReportEntry("master-ptp-config", masterPtpConfigStr)
+				ptpReporter.AddReportEntry("slave-ptp-config", slavePtpConfigStr)
 			})
 		})
 		Context("PTP ClockSync", func() {

--- a/vendor/github.com/test-network-function/privileged-daemonset/Makefile
+++ b/vendor/github.com/test-network-function/privileged-daemonset/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 # Variables
-GOLANGCI_VERSION=v1.49.0
+GOLANGCI_VERSION=v1.50.1
 
 vet:
 	go vet ${GO_PACKAGES}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -247,7 +247,7 @@ github.com/test-network-function/l2discovery-exports
 github.com/test-network-function/l2discovery-lib
 github.com/test-network-function/l2discovery-lib/pkg/l2client
 github.com/test-network-function/l2discovery-lib/pkg/pods
-# github.com/test-network-function/privileged-daemonset v0.0.0-20221007131241-54f0523bd810
+# github.com/test-network-function/privileged-daemonset v0.0.1
 ## explicit; go 1.19
 github.com/test-network-function/privileged-daemonset
 # github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869


### PR DESCRIPTION
Dump ptp hw details obtained in the corresponding test case as report entries (system-out xml node). The logrus traces have also been updated to include the node name, as interface names are usually the same. Updated file: test/conformance/ptp/ptp.go

The TC in the junit file will appear like this (unscapped):
```
<system-out>Report Entries:
Node worker-1.clus0.t5g.lab.eng.rdu2.redhat.com, Interface: ens3f0
Device: 0000:d8:00, Function: 0, Description: Ethernet controller: ...
--
Node worker-1.clus0.t5g.lab.eng.rdu2.redhat.com, Interface: ens3f1
Device: 0000:d8:00, Function: 1, Description: Ethernet controller: ...
--
Node worker-0.clus0.t5g.lab.eng.rdu2.redhat.com, Interface: ens3f0
Device: 0000:d8:00, Function: 0, Description: Ethernet controller: ...
--
Node worker-0.clus0.t5g.lab.eng.rdu2.redhat.com, Interface: ens3f1
Device: 0000:d8:00, Function: 1, Description: Ethernet controller: ...
--
...
...
--
master-ptp-config
test-grandmaster
--
slave-ptp-config
test-slave1
</system-out>
```
Also, the project has been updated to use the latest release of the privilege-daemonset module as it fixes a rare bug. See: https://github.com/test-network-function/privileged-daemonset/pull/19