### PR TITLE
PTP operator: Use priority class node critical

### DIFF
--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -359,6 +359,7 @@ spec:
                   readOnly: true
               nodeSelector:
                 node-role.kubernetes.io/master: ""
+              priorityClassName: "system-node-critical"
               serviceAccountName: ptp-operator
               tolerations:
               - effect: NoSchedule

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,7 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       serviceAccountName: ptp-operator
+      priorityClassName: "system-node-critical"
       containers:
         - name: ptp-operator
           # Replaces this with the image name

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -351,6 +351,7 @@ spec:
                   readOnly: true
               nodeSelector:
                 node-role.kubernetes.io/master: ""
+              priorityClassName: "system-node-critical"
               serviceAccountName: ptp-operator
               tolerations:
               - effect: NoSchedule


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
fix: PTP operator: Use priority class node critical for ptp-operator