### PR TITLE
fix naming convention

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -3,7 +3,7 @@ updates:
     update_list:
     # replace metadata.name value
     - search: "ptp-operator.v{MAJOR}.{MINOR}.0"
-      replace: "ptp-operator.{FULL_VER}"
+      replace: "ptp-operator.v{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
     - search: 'olm.skipRange: ">=4.3.0-0 <{MAJOR}.{MINOR}.0"'


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12 
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-ptp-operator-metadata-container-v4.12.0.202211151637.p0.g0229788.assembly.stream-1/26666b23-0cfe-4fce-8290-878ec9314f26/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.