### PR TITLE
Bug OCPBUGS-4434: Filtering Virtual interfaces from list of viable ptp interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/test-network-function/graphsolver-lib v0.0.2
 	github.com/test-network-function/l2discovery-exports v0.0.1
-	github.com/test-network-function/l2discovery-lib v0.0.4
+	github.com/test-network-function/l2discovery-lib v0.0.5
 	github.com/test-network-function/privileged-daemonset v0.0.5
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.25.4

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/test-network-function/graphsolver-lib v0.0.2 h1:s/2petXZPAlG7Gh7ra7hi
 github.com/test-network-function/graphsolver-lib v0.0.2/go.mod h1:X9HIBAST5obDb8YMWykMIOU9iwouT2wrR1yLpTRmXQM=
 github.com/test-network-function/l2discovery-exports v0.0.1 h1:4/49T2Js92JyOAO8T+0vnV8zy5z6WaV1GCfLGmEgs7g=
 github.com/test-network-function/l2discovery-exports v0.0.1/go.mod h1:LXzJLrM5Ao0j4pN/HnlYrBQDpO3TCtlfiK4HmRk2ps8=
-github.com/test-network-function/l2discovery-lib v0.0.4 h1:EggRNkFC8JiaAg0eqvYOHJE3+tsBO4cd7zh8B5J6xXU=
-github.com/test-network-function/l2discovery-lib v0.0.4/go.mod h1:h3UimGqykQ92YTeCsQekV3pU+rFcPOmPxS2ZEFhxSY0=
+github.com/test-network-function/l2discovery-lib v0.0.5 h1:rgH5Y7lIu0R7L4uXEu2f9UAL9DTZ+vaUGuKBjy+UMY0=
+github.com/test-network-function/l2discovery-lib v0.0.5/go.mod h1:h3UimGqykQ92YTeCsQekV3pU+rFcPOmPxS2ZEFhxSY0=
 github.com/test-network-function/privileged-daemonset v0.0.5 h1:0afeyGyrS5zAaMIT0Yp/scOzkUlGgZqjjBThd2MLmRQ=
 github.com/test-network-function/privileged-daemonset v0.0.5/go.mod h1:u9QKZcNRCb6Idf9MtaHe19XshRIGDzLZjk54vfmJUrk=
 github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869 h1:7v7L5lsfw4w8iqBBXETukHo4IPltmD+mWoLRYUmeGN8=

--- a/vendor/github.com/test-network-function/l2discovery-lib/l2lib.go
+++ b/vendor/github.com/test-network-function/l2discovery-lib/l2lib.go
@@ -249,7 +249,8 @@ func (config *L2DiscoveryConfig) createL2InternalGraph(ptpInterfacesOnly bool) e
 				if v, ok := config.ClusterIndexToInt[l2.IfClusterIndex{InterfaceName: iface, NodeName: aPod.Spec.NodeName}]; ok {
 					if w, ok := config.ClusterMacToInt[mac]; ok {
 						if ptpInterfacesOnly &&
-							(!config.PtpIfList[v].IfPTPCaps.HwRx ||
+							(strings.Contains(config.PtpIfList[v].IfPci.Description, "Virtual") ||
+								!config.PtpIfList[v].IfPTPCaps.HwRx ||
 								!config.PtpIfList[v].IfPTPCaps.HwTx ||
 								!config.PtpIfList[v].IfPTPCaps.HwRawClock ||
 								!config.PtpIfList[w].IfPTPCaps.HwRx ||
@@ -286,7 +287,8 @@ func (config *L2DiscoveryConfig) getInterfacesReceivingPTP(ptpInterfacesOnly boo
 			aPortGettingPTP.InterfaceName = aPortGettingPTP.Iface.IfName
 
 			if ptpInterfacesOnly &&
-				(!aPortGettingPTP.IfPTPCaps.HwRx ||
+				(strings.Contains(aPortGettingPTP.IfPci.Description, "Virtual") ||
+					!aPortGettingPTP.IfPTPCaps.HwRx ||
 					!aPortGettingPTP.IfPTPCaps.HwTx ||
 					!aPortGettingPTP.IfPTPCaps.HwRawClock) {
 				continue
@@ -340,7 +342,8 @@ func (config *L2DiscoveryConfig) updateMaps(disc map[string]map[string]*l2.Neigh
 		aInterface.Iface = ifaceData.Local
 
 		if ptpInterfacesOnly &&
-			(!aInterface.IfPTPCaps.HwRx ||
+			(strings.Contains(aInterface.IfPci.Description, "Virtual") ||
+				!aInterface.IfPTPCaps.HwRx ||
 				!aInterface.IfPTPCaps.HwTx ||
 				!aInterface.IfPTPCaps.HwRawClock) {
 			continue

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -232,7 +232,7 @@ github.com/test-network-function/graphsolver-lib
 # github.com/test-network-function/l2discovery-exports v0.0.1
 ## explicit; go 1.19
 github.com/test-network-function/l2discovery-exports
-# github.com/test-network-function/l2discovery-lib v0.0.4
+# github.com/test-network-function/l2discovery-lib v0.0.5
 ## explicit; go 1.19
 github.com/test-network-function/l2discovery-lib
 github.com/test-network-function/l2discovery-lib/pkg/l2client


### PR DESCRIPTION
This is to fix for an intermittent failure in cnf-feature-deploy