### PR TITLE
Adding multi-node support for ptp events

### DIFF
--- a/bindata/linuxptp/event-service.yaml
+++ b/bindata/linuxptp/event-service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "false"
+    service.beta.openshift.io/serving-cert-secret-name: linuxptp-daemon-secret
+  labels:
+    app: linuxptp-daemon
+  name:  ptp-event-publisher-service-{{.NodeName}}
+  namespace: openshift-ptp
+spec:
+  selector:
+    app: linuxptp-daemon
+    nodeName: {{.NodeName}}
+  ports:
+    - name: publisher-port
+      port: 9043
+  sessionAffinity: None
+  type: ClusterIP

--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -100,6 +100,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: LOGS_TO_SOCKET
               value: "{{ .EnableEventPublisher }}"
           volumeMounts:
@@ -173,28 +177,6 @@ spec:
       targetPort: https
   sessionAffinity: None
   type: ClusterIP
-  {{ if (eq .EnableEventPublisher true) }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    prometheus.io/scrape: "false"
-    service.beta.openshift.io/serving-cert-secret-name: linuxptp-daemon-secret
-  labels:
-    app: linuxptp-daemon
-  name:  ptp-event-publisher-service
-  namespace: openshift-ptp
-spec:
-  selector:
-    app: linuxptp-daemon
-  clusterIP: None
-  ports:
-    - name: publisher-port
-      port: 9043
-  sessionAffinity: None
-  type: ClusterIP
-  {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/custom/rbac.yaml
+++ b/config/custom/rbac.yaml
@@ -67,6 +67,9 @@ rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Work in progress!!

This PR creates one  ptp-event-publisher-service-xxx per node and an ingress object per cluster for ptp-events. For the ingress object, one backend is created per node to direclty access the ptp events service on that node.
![image](https://user-images.githubusercontent.com/86730676/206752208-de287a5d-4560-4a13-8ab7-ca017356aa13.png)
requires an new nodeName label on the linux-ptp-daemon. See related PR: https://github.com/openshift/linuxptp-daemon/pull/107
