### PR TITLE
Validation tests: Check pods status in an Eventually

### DIFF
--- a/test/pkg/consts.go
+++ b/test/pkg/consts.go
@@ -39,6 +39,7 @@ const (
 	TimeoutIn5Minutes          = 5 * time.Minute
 	TimeoutIn10Minutes         = 10 * time.Minute
 	Timeout10Seconds           = 10 * time.Second
+	TimeoutInterval2Seconds    = 2 * time.Second
 
 	MasterOffsetLowerBound  = -100
 	MasterOffsetHigherBound = 100


### PR DESCRIPTION
When running the validation tests just after the operator deployment the tests can fail if the pods are not ready yet. To avoid this, the pods validation should be done in an Eventually.