### PR TITLE
Add storageType and set default transportHost to HTTP

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -36,4 +36,7 @@ resources:
   kind: PtpOperatorConfig
   path: github.com/openshift/ptp-operator/api/v1
   version: v1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ items:
   spec:
     ptpEventConfig:
       enableEventPublisher: true
-      transportHost: "http://ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
       # For AMQP transport, transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+      transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
+      storageType: local-sc
     daemonNodeSelector:
       node-role.kubernetes.io/worker: ""
 kind: List

--- a/api/v1/ptpconfig_webhook.go
+++ b/api/v1/ptpconfig_webhook.go
@@ -46,6 +46,8 @@ func (r *PtpConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
+//+kubebuilder:webhook:path=/validate-ptp-openshift-io-v1-ptpconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=ptp.openshift.io,resources=ptpconfigs,verbs=create;update,versions=v1,name=vptpconfig.kb.io,admissionReviewVersions=v1
+
 type ptp4lConfSection struct {
 	options map[string]string
 }

--- a/api/v1/ptpoperatorconfig_types.go
+++ b/api/v1/ptpoperatorconfig_types.go
@@ -68,11 +68,14 @@ type PtpEventConfig struct {
 	// +kubebuilder:default=false
 	// EnableEventPublisher will deploy event proxy as a sidecar
 	EnableEventPublisher bool `json:"enableEventPublisher,omitempty"`
-	// TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
-	// Example HTTP transport: "http://ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
+	// TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>
+	// Example HTTP transport: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
 	// Example AMQP transport: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local"
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Transport Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	TransportHost string `json:"transportHost,omitempty"`
+	// StorageType is the name of StorageClass providing persist storage used by HTTP transport to store subscription data
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	StorageType string `json:"storageType,omitempty"`
 }
 
 func init() {

--- a/api/v1/ptpoperatorconfig_webhook.go
+++ b/api/v1/ptpoperatorconfig_webhook.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"errors"
+	"net/url"
+
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var ptpoperatorconfiglog = logf.Log.WithName("ptpoperatorconfig-resource")
+
+var k8sclient client.Client
+
+func (r *PtpOperatorConfig) SetupWebhookWithManager(mgr ctrl.Manager, client client.Client) error {
+	k8sclient = client
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-ptp-openshift-io-v1-ptpoperatorconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=ptp.openshift.io,resources=ptpoperatorconfigs,verbs=update,versions=v1,name=vptpoperatorconfig.kb.io,admissionReviewVersions=v1
+
+const (
+	AmqScheme = "amqp"
+	// storageTypeEmptyDir is used for developer tests to map pubsubstore volume to emptyDir
+	storageTypeEmptyDir = "emptyDir"
+)
+
+func (r *PtpOperatorConfig) validate() error {
+	eventConfig := r.Spec.EventConfig
+	if eventConfig.EnableEventPublisher {
+		transportUrl, err := url.Parse(eventConfig.TransportHost)
+		if err == nil && transportUrl.Scheme == AmqScheme {
+			return nil
+		}
+		if eventConfig.StorageType == "" {
+			return errors.New("for HTTP transport, ptpEventConfig.storageType must be set to the name of StorageClass providing persist storage")
+		}
+		if eventConfig.StorageType != storageTypeEmptyDir && !r.checkStorageClass(eventConfig.StorageType) {
+			return errors.New("ptpEventConfig.storageType is set to StorageClass " + eventConfig.StorageType + " which does not exist")
+		}
+	}
+	return nil
+}
+
+var _ webhook.Validator = &PtpOperatorConfig{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *PtpOperatorConfig) ValidateCreate() error {
+	ptpoperatorconfiglog.Info("validate create", "name", r.Name)
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *PtpOperatorConfig) ValidateUpdate(old runtime.Object) error {
+	ptpoperatorconfiglog.Info("validate update", "name", r.Name)
+	return r.validate()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *PtpOperatorConfig) ValidateDelete() error {
+	ptpoperatorconfiglog.Info("validate delete", "name", r.Name)
+	return nil
+}
+
+func (r *PtpOperatorConfig) checkStorageClass(scName string) bool {
+
+	scList := &storagev1.StorageClassList{}
+	opts := []client.ListOption{}
+	err := k8sclient.List(context.TODO(), scList, opts...)
+	if err != nil {
+		return false
+	}
+
+	for _, sc := range scList.Items {
+		if sc.Name == scName {
+			return true
+		}
+	}
+	return false
+}

--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -127,11 +127,11 @@ spec:
             secretName: linuxptp-daemon-secret
         {{ if (eq .EnableEventPublisher true) }}
         - name: pubsubstore
-          {{ if not (hasPrefix "amqp" .EventTransportHost) }}
-          persistentVolumeClaim:
-            claimName: cloud-event-proxy-store
-          {{ else }}
+          {{ if or (eq .StorageType "emptyDir") (hasPrefix "amqp" .EventTransportHost) }}
           emptyDir: {}
+          {{ else }}
+          persistentVolumeClaim:
+            claimName: cloud-event-proxy-store-{{ .StorageType }}
           {{ end }}
         - name: event-bus-socket
           emptyDir: {}
@@ -252,23 +252,21 @@ spec:
             severity: warning
         {{ end }}
 
-{{ if and (eq .EnableEventPublisher true) (not (hasPrefix "amqp" .EventTransportHost)) }}
+# special storageType "emptyDir" is used for developer tests to map pubsubstore volume to emptyDir
+{{ if and (eq .EnableEventPublisher true) (ne .StorageType "emptyDir") }}
+{{ if not (hasPrefix "amqp" .EventTransportHost) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: cloud-event-proxy-store
+  name: cloud-event-proxy-store-{{ .StorageType }}
   namespace: openshift-ptp
 spec:
-  # By default use the (default) storageClass.
-  # Use the following command to patch a storageClass as default.
-  # oc patch storageclass example-storage-class -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-  # To use a specific storageClass, uncomment the following line and replace the place holder
-  # with the name of storage class.
-  # storageClassName: <storage-class-name>
+  storageClassName: {{ .StorageType }}
   resources:
     requests:
       storage: 10Mi
   accessModes:
   - ReadWriteOnce
+{{ end }}
 {{ end }}

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -93,8 +93,14 @@ spec:
       kind: PtpOperatorConfig
       name: ptpoperatorconfigs.ptp.openshift.io
       specDescriptors:
-      - description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
-          Example HTTP transport: "http://ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
+      - description: StorageType is the name of StorageClass providing persist storage
+          used by HTTP transport to store subscription data
+        displayName: Storage Type
+        path: ptpEventConfig.storageType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>
+          Example HTTP transport: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
           Example AMQP transport: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local"'
         displayName: Transport Host
         path: ptpEventConfig.transportHost
@@ -254,12 +260,29 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - '*'
+        - apiGroups:
           - config.openshift.io
           resources:
           - infrastructures
           verbs:
           - get
           - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
           - watch
         - apiGroups:
           - ptp.openshift.io
@@ -453,11 +476,10 @@ spec:
   webhookdefinitions:
   - admissionReviewVersions:
     - v1
-    - v1beta1
     containerPort: 443
     deploymentName: ptp-operator
     failurePolicy: Fail
-    generateName: ptpconfigvalidationwebhook.openshift.io
+    generateName: vptpconfig.kb.io
     rules:
     - apiGroups:
       - ptp.openshift.io
@@ -472,3 +494,22 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-ptp-openshift-io-v1-ptpconfig
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: ptp-operator
+    failurePolicy: Fail
+    generateName: vptpoperatorconfig.kb.io
+    rules:
+    - apiGroups:
+      - ptp.openshift.io
+      apiVersions:
+      - v1
+      operations:
+      - UPDATE
+      resources:
+      - ptpoperatorconfigs
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-ptp-openshift-io-v1-ptpoperatorconfig

--- a/bundle/manifests/ptp.openshift.io_ptpoperatorconfigs.yaml
+++ b/bundle/manifests/ptp.openshift.io_ptpoperatorconfigs.yaml
@@ -55,9 +55,14 @@ spec:
                     description: EnableEventPublisher will deploy event proxy as a
                       sidecar
                     type: boolean
+                  storageType:
+                    description: StorageType is the name of StorageClass providing
+                      persist storage used by HTTP transport to store subscription
+                      data
+                    type: string
                   transportHost:
-                    description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
-                      Example HTTP transport: "http://ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
+                    description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>
+                      Example HTTP transport: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
                       Example AMQP transport: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local"'
                     type: string
                 type: object

--- a/bundle/manifests/webhook-service_v1_service.yaml
+++ b/bundle/manifests/webhook-service_v1_service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   creationTimestamp: null
-  name: ptpconfig-validator-webhook-service
+  name: webhook-service
 spec:
   ports:
   - port: 443

--- a/config/crd/bases/ptp.openshift.io_ptpoperatorconfigs.yaml
+++ b/config/crd/bases/ptp.openshift.io_ptpoperatorconfigs.yaml
@@ -56,9 +56,14 @@ spec:
                     description: EnableEventPublisher will deploy event proxy as a
                       sidecar
                     type: boolean
+                  storageType:
+                    description: StorageType is the name of StorageClass providing
+                      persist storage used by HTTP transport to store subscription
+                      data
+                    type: string
                   transportHost:
-                    description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
-                      Example HTTP transport: "http://ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
+                    description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>
+                      Example HTTP transport: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
                       Example AMQP transport: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local"'
                     type: string
                 type: object

--- a/config/custom/rbac.yaml
+++ b/config/custom/rbac.yaml
@@ -55,6 +55,9 @@ rules:
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["*"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -86,8 +86,14 @@ spec:
       kind: PtpOperatorConfig
       name: ptpoperatorconfigs.ptp.openshift.io
       specDescriptors:
-      - description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
-          Example HTTP transport: "http://ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
+      - description: StorageType is the name of StorageClass providing persist storage
+          used by HTTP transport to store subscription data
+        displayName: Storage Type
+        path: ptpEventConfig.storageType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>
+          Example HTTP transport: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
           Example AMQP transport: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local"'
         displayName: Transport Host
         path: ptpEventConfig.transportHost

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - ptp.openshift.io
   resources:
   - ptpconfigs

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -4,3 +4,10 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patches:
+- path: patches/patch_webhook_configuration.yaml
+  target:
+    version: v1
+    kind: ValidatingWebhookConfiguration
+    name: validating-webhook-configuration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,18 +2,18 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: ptpconfig-validating-webhook-configuration
+  creationTimestamp: null
+  name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
-      name: ptpconfig-validator-webhook-service
+      name: webhook-service
       namespace: system
       path: /validate-ptp-openshift-io-v1-ptpconfig
   failurePolicy: Fail
-  name: ptpconfigvalidationwebhook.openshift.io
+  name: vptpconfig.kb.io
   rules:
   - apiGroups:
     - ptp.openshift.io
@@ -24,4 +24,23 @@ webhooks:
     - UPDATE
     resources:
     - ptpconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-ptp-openshift-io-v1-ptpoperatorconfig
+  failurePolicy: Fail
+  name: vptpoperatorconfig.kb.io
+  rules:
+  - apiGroups:
+    - ptp.openshift.io
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    resources:
+    - ptpoperatorconfigs
   sideEffects: None

--- a/config/webhook/patches/patch_webhook_configuration.yaml
+++ b/config/webhook/patches/patch_webhook_configuration.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/name
+  value: ptpconfig-validating-webhook-configuration

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ptpconfig-validator-webhook-service
+  name: webhook-service
   namespace: openshift-ptp
   annotations:
       service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -65,18 +66,22 @@ type EventTransportHostStatus struct {
 const (
 	ResyncPeriod = 2 * time.Minute
 	// AmqReadyStateError Event related transport protocol const
-	AmqReadyStateError         = "AMQ not ready"
-	TransportRetryMaxCount     = 12 // max 3 minutes
-	RsyncTransportRetryPeriod  = 10 * time.Second
-	DefaultTransportHostScheme = "amqp"
-	DefaultTransportHostName   = "nohup"
-	AmqDefaultHost             = DefaultTransportHostScheme + "://" + DefaultTransportHostName
+	AmqReadyStateError        = "AMQ not ready"
+	TransportRetryMaxCount    = 12 // max 3 minutes
+	RsyncTransportRetryPeriod = 10 * time.Second
+	AmqScheme                 = "amqp"
+	AmqDefaultHostName        = "nohup"
+	AmqDefaultHost            = AmqScheme + "://" + AmqDefaultHostName
+	DefaultTransportHost      = "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
+	DefaultStorageType        = "emptyDir"
+	PVCNamePrefix             = "cloud-event-proxy-store"
 )
 
 //+kubebuilder:rbac:groups=ptp.openshift.io,resources=ptpoperatorconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ptp.openshift.io,resources=ptpoperatorconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ptp.openshift.io,resources=ptpoperatorconfigs/finalizers,verbs=update
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete
 
 func (r *PtpOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile.Result, error) {
 	reqLogger := r.Log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
@@ -186,6 +191,62 @@ func (r *PtpOperatorConfigReconciler) setDaemonNodeSelector(
 	return obj, nil
 }
 
+// syncPvc update PersistentVolumeClaim
+func (r *PtpOperatorConfigReconciler) syncPvc(ctx context.Context, obj *uns.Unstructured) (*uns.Unstructured, error) {
+	var err error
+	scheme := kscheme.Scheme
+	pvc := &corev1.PersistentVolumeClaim{}
+	err = scheme.Convert(obj, pvc, nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert obj to corev1.PersistentVolumeClaim: %v", err)
+	}
+
+	// update the VolumeName of PVC when the PVC is bound to a PV
+	if pvcDeployed := r.getPvc(obj.GetName(), names.Namespace); pvcDeployed != nil {
+		if pvcDeployed.Spec.VolumeName != pvc.Spec.VolumeName && pvc.Spec.VolumeName == "" {
+			log.Printf("pvc %s is Bound, updating VolumeName to %s", obj.GetName(), pvcDeployed.Spec.VolumeName)
+			pvc.Spec.VolumeName = pvcDeployed.Spec.VolumeName
+		}
+	}
+
+	err = scheme.Convert(pvc, obj, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert corev1.PersistentVolumeClaim to obj: %v", err)
+	}
+
+	return obj, nil
+}
+
+// cleanupPvc clean up obsolete PVCs not mounted to current lixnuxptp pod
+func (r *PtpOperatorConfigReconciler) cleanupPvc(ctx context.Context, storageType string) error {
+	var err error
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	opts := []client.ListOption{
+		client.InNamespace(names.Namespace),
+	}
+	err = r.List(context.TODO(), pvcList, opts...)
+	if err != nil {
+		return err
+	}
+
+	pvcName := fmt.Sprintf("%s-%s", PVCNamePrefix, storageType)
+
+	for _, p := range pvcList.Items {
+		if strings.HasPrefix(p.ObjectMeta.Name, PVCNamePrefix) {
+			if p.ObjectMeta.Name != pvcName || storageType == DefaultStorageType {
+				if err := r.Client.Delete(ctx, &p); err != nil {
+					log.Printf("fail to delete obsolete pvc %s err: %v", p.ObjectMeta.Name, err)
+				} else {
+					log.Printf("garbage collection: successfully deleted obsolete pvc %s", p.ObjectMeta.Name)
+				}
+			}
+		}
+
+	}
+	return nil
+}
+
 // syncLinuxptpDaemon synchronizes Linuxptp DaemonSet
 func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, defaultCfg *ptpv1.PtpOperatorConfig, nodeList *corev1.NodeList) error {
 	var err error
@@ -198,6 +259,7 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 	data.Data["KubeRbacProxy"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["SideCar"] = os.Getenv("SIDECAR_EVENT_IMAGE")
 	data.Data["NodeName"] = os.Getenv("NODE_NAME")
+	data.Data["StorageType"] = DefaultStorageType
 	// configure EventConfig
 	if defaultCfg.Spec.EventConfig == nil {
 		data.Data["EnableEventPublisher"] = false
@@ -211,6 +273,9 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 				return e
 			}
 			data.Data["EventTransportHost"] = transportHost
+			if defaultCfg.Spec.EventConfig.StorageType != "" {
+				data.Data["StorageType"] = defaultCfg.Spec.EventConfig.StorageType
+			}
 		}
 	}
 
@@ -235,11 +300,24 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 		return fmt.Errorf("failed to render linuxptp daemon manifest: %v", err)
 	}
 
+	err = r.cleanupPvc(ctx, fmt.Sprintf("%s", data.Data["StorageType"]))
+	if err != nil {
+		return err
+	}
+
 	for _, obj := range objs {
 		obj, err = r.setDaemonNodeSelector(defaultCfg, obj)
 		if err != nil {
 			return err
 		}
+
+		if obj.GetKind() == "PersistentVolumeClaim" {
+			obj, err = r.syncPvc(ctx, obj)
+			if err != nil {
+				return err
+			}
+		}
+
 		if err = controllerutil.SetControllerReference(defaultCfg, obj, r.Scheme); err != nil {
 			return fmt.Errorf("failed to set owner reference for daemon: %v", err)
 		}
@@ -326,8 +404,8 @@ func (r *PtpOperatorConfigReconciler) EventTransportHostAvailabilityCheck(transp
 	var transportUrl *url.URL
 	if transportHost == "" {
 		glog.Warningf("ptp operator config Spec, ptpEventConfig.transportHost=%v is not valid, proceed as %s",
-			transportHost, AmqDefaultHost)
-		return AmqDefaultHost, nil
+			transportHost, DefaultTransportHost)
+		return DefaultTransportHost, nil
 	}
 
 	// if new transport has been applied reset everything
@@ -338,8 +416,8 @@ func (r *PtpOperatorConfigReconciler) EventTransportHostAvailabilityCheck(transp
 	transportUrl, err := url.Parse(transportHost)
 	if err != nil {
 		glog.Warningf("ptp operator config Spec, ptpEventConfig.transportHost=%v is not valid, proceed as %s",
-			transportHost, AmqDefaultHost)
-		return AmqDefaultHost, nil
+			transportHost, DefaultTransportHost)
+		return DefaultTransportHost, nil
 	} else if r.TransportHostStatus.RetryThisHost(transportUrl.Scheme, transportUrl.Host) { // not set to nohup and last try was not success
 		if r.TransportHostStatus.RetryOnCount() {
 			if amq := strings.Split(transportUrl.Host, "."); len(amq) > 1 { // check for availability if its amq
@@ -357,6 +435,25 @@ func (r *PtpOperatorConfigReconciler) EventTransportHostAvailabilityCheck(transp
 	} // else not checking for amq://localhost:5672 or http
 	r.TransportHostStatus.Exit()
 	return transportHost, nil
+}
+
+func (r *PtpOperatorConfigReconciler) getPvc(pvcName string, namespace string) *corev1.PersistentVolumeClaim {
+
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	opts := []client.ListOption{
+		client.InNamespace(namespace),
+	}
+	err := r.List(context.TODO(), pvcList, opts...)
+	if err != nil {
+		return nil
+	}
+	for _, p := range pvcList.Items {
+		if p.ObjectMeta.Name == pvcName {
+			return &p
+		}
+
+	}
+	return nil
 }
 
 // Inc count
@@ -390,8 +487,8 @@ func (e *EventTransportHostStatus) Exit() {
 
 // RetryThisHost ... check if retry  needed for this host
 func (e *EventTransportHostStatus) RetryThisHost(scheme, host string) bool {
-	if scheme == DefaultTransportHostScheme &&
-		host != DefaultTransportHostName &&
+	if scheme == AmqScheme &&
+		host != AmqDefaultHostName &&
 		!e.Success {
 		return true
 	}

--- a/main.go
+++ b/main.go
@@ -112,6 +112,11 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
+	if err = (&ptpv1.PtpOperatorConfig{}).SetupWebhookWithManager(mgr, mgr.GetClient()); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "PtpOperatorConfig")
+		os.Exit(1)
+	}
+
 	err = createDefaultOperatorConfig(ctrl.GetConfigOrDie())
 	if err != nil {
 		setupLog.Error(err, "unable to create default PtpOperatorConfig")

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -93,8 +93,14 @@ spec:
       kind: PtpOperatorConfig
       name: ptpoperatorconfigs.ptp.openshift.io
       specDescriptors:
-      - description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
-          Example HTTP transport: "http://ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
+      - description: StorageType is the name of StorageClass providing persist storage
+          used by HTTP transport to store subscription data
+        displayName: Storage Type
+        path: ptpEventConfig.storageType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>
+          Example HTTP transport: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
           Example AMQP transport: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local"'
         displayName: Transport Host
         path: ptpEventConfig.transportHost
@@ -254,12 +260,29 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - '*'
+        - apiGroups:
           - config.openshift.io
           resources:
           - infrastructures
           verbs:
           - get
           - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
           - watch
         - apiGroups:
           - ptp.openshift.io
@@ -453,11 +476,10 @@ spec:
   webhookdefinitions:
   - admissionReviewVersions:
     - v1
-    - v1beta1
     containerPort: 443
     deploymentName: ptp-operator
     failurePolicy: Fail
-    generateName: ptpconfigvalidationwebhook.openshift.io
+    generateName: vptpconfig.kb.io
     rules:
     - apiGroups:
       - ptp.openshift.io
@@ -472,3 +494,22 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-ptp-openshift-io-v1-ptpconfig
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: ptp-operator
+    failurePolicy: Fail
+    generateName: vptpoperatorconfig.kb.io
+    rules:
+    - apiGroups:
+      - ptp.openshift.io
+      apiVersions:
+      - v1
+      operations:
+      - UPDATE
+      resources:
+      - ptpoperatorconfigs
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-ptp-openshift-io-v1-ptpoperatorconfig

--- a/manifests/stable/ptp.openshift.io_ptpoperatorconfigs.yaml
+++ b/manifests/stable/ptp.openshift.io_ptpoperatorconfigs.yaml
@@ -55,9 +55,14 @@ spec:
                     description: EnableEventPublisher will deploy event proxy as a
                       sidecar
                     type: boolean
+                  storageType:
+                    description: StorageType is the name of StorageClass providing
+                      persist storage used by HTTP transport to store subscription
+                      data
+                    type: string
                   transportHost:
-                    description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
-                      Example HTTP transport: "http://ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
+                    description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>
+                      Example HTTP transport: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
                       Example AMQP transport: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local"'
                     type: string
                 type: object

--- a/manifests/stable/webhook-service_v1_service.yaml
+++ b/manifests/stable/webhook-service_v1_service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   creationTimestamp: null
-  name: ptpconfig-validator-webhook-service
+  name: webhook-service
 spec:
   ports:
   - port: 443


### PR DESCRIPTION
This PR introduces a new field `storageType` in PtpOperatorConfig spec. 
The `storageType` is for HTTP transport only. HTTP transport requires persistent storage for storing subscription data. The `storageType` must be set to the name of StorageClass providing the persist storage.

The example below assumes PVs are provisioned or will be dynamically provisioned by StorageClass named "local-sc".
```
apiVersion: ptp.openshift.io/v1
kind: PtpOperatorConfig
metadata:
  generation: 1
  name: default
  namespace: openshift-ptp
spec:
  daemonNodeSelector: {}
  ptpEventConfig:
    enableEventPublisher: true
    transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
    storageType: "local-sc"

```
If HTTP transport is used but `storageType` is missing or empty, the `PtpOperatorConfig` will fail to apply with the following error:
>for HTTP transport, ptpEventConfig.storageType must be set to the name of StorageClass providing persist storage

If `transportHost` is missing or empty, the default transportHost `"http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"` is used. In this case a valid `storageType` is still required.

A special storageType `emptyDir` is used for developers only. It provides ephemeral storage for HTTP transport and is used for developer testings.
