### PR TITLE
[release-4.12] Fix URI for PTP events conformance tests

### DIFF
--- a/test/conformance/ptp/ptp.go
+++ b/test/conformance/ptp/ptp.go
@@ -493,7 +493,7 @@ var _ = Describe("[ptp]", func() {
 				By("Checking event api is healthy")
 				for podIndex := range ptpSlaveRunningPods {
 					Eventually(func() string {
-						buf, _ := pods.ExecCommand(client.Client, &ptpSlaveRunningPods[podIndex], pkg.EventProxyContainerName, []string{"curl", "127.0.0.1:9085/api/cloudNotifications/v1/health"})
+						buf, _ := pods.ExecCommand(client.Client, &ptpSlaveRunningPods[podIndex], pkg.EventProxyContainerName, []string{"curl", "127.0.0.1:9085/api/ocloudNotifications/v1/health"})
 						return buf.String()
 					}, pkg.TimeoutIn5Minutes, 5*time.Second).Should(ContainSubstring("OK"),
 						"Event API is not in healthy state")
@@ -502,7 +502,7 @@ var _ = Describe("[ptp]", func() {
 				By("Checking ptp publisher is created")
 				for podIndex := range ptpSlaveRunningPods {
 					Eventually(func() string {
-						buf, _ := pods.ExecCommand(client.Client, &ptpSlaveRunningPods[podIndex], pkg.EventProxyContainerName, []string{"curl", "127.0.0.1:9085/api/cloudNotifications/v1/publishers"})
+						buf, _ := pods.ExecCommand(client.Client, &ptpSlaveRunningPods[podIndex], pkg.EventProxyContainerName, []string{"curl", "127.0.0.1:9085/api/ocloudNotifications/v1/publishers"})
 						return buf.String()
 					}, pkg.TimeoutIn5Minutes, 5*time.Second).Should(ContainSubstring("endpointUri"),
 						"Event API  did not return publishers")


### PR DESCRIPTION
[1] changed the URI for the cloud notifications URI to be ocloudNotifications instead of cloudNotifications. This patch updates the PTP events conformance test to match.

[1] - https://github.com/redhat-cne/cloud-event-proxy/commit/e527530f613ff0d5cecadccdeec3a24ff1be913b