### PR TITLE
[release-4.11] Fix URI for PTP events conformance tests

### DIFF
--- a/test/conformance/ptp/ptp.go
+++ b/test/conformance/ptp/ptp.go
@@ -385,7 +385,7 @@ var _ = Describe("[ptp]", func() {
 				By("Checking event api is healthy")
 				for _, pod := range ptpSlaveRunningPods {
 					Eventually(func() string {
-						buf, _ := pods.ExecCommand(client.Client, pod, EventProxyContainerName, []string{"curl", "127.0.0.1:9085/api/cloudNotifications/v1/health"})
+						buf, _ := pods.ExecCommand(client.Client, pod, EventProxyContainerName, []string{"curl", "127.0.0.1:9085/api/ocloudNotifications/v1/health"})
 						return buf.String()
 					}, 5*time.Minute, 5*time.Second).Should(ContainSubstring("OK"),
 						"Event API is not in healthy state")
@@ -394,7 +394,7 @@ var _ = Describe("[ptp]", func() {
 				By("Checking ptp publisher is created")
 				for _, pod := range ptpSlaveRunningPods {
 					Eventually(func() string {
-						buf, _ := pods.ExecCommand(client.Client, pod, EventProxyContainerName, []string{"curl", "127.0.0.1:9085/api/cloudNotifications/v1/publishers"})
+						buf, _ := pods.ExecCommand(client.Client, pod, EventProxyContainerName, []string{"curl", "127.0.0.1:9085/api/ocloudNotifications/v1/publishers"})
 						return buf.String()
 					}, 5*time.Minute, 5*time.Second).Should(ContainSubstring("endpointUri"),
 						"Event API  did not return publishers")


### PR DESCRIPTION
[1] changed the URI for the cloud notifications URI to be ocloudNotifications instead of cloudNotifications. This patch updates the PTP events conformance test to match.

[1] - https://github.com/redhat-cne/cloud-event-proxy/commit/aabc4225c1fdf3c387f1beb7f65f8f73566745d5

(cherry picked from commit 8fcabb9c4b996b14bccdc4cd24f87af73e4e24a0)