### PR TITLE
using non-default namespace for privileged-daemonset

### DIFF
--- a/test/pkg/consts.go
+++ b/test/pkg/consts.go
@@ -49,11 +49,11 @@ const (
 	MetricsEndPoint       = "127.0.0.1:9091/metrics"
 	PtpConfigOperatorName = "default"
 
-	RebootDaemonSetNamespace     = "default"
+	RebootDaemonSetNamespace     = "ptp-reboot"
 	RebootDaemonSetName          = "ptp-reboot"
 	RebootDaemonSetContainerName = "container-00"
 
-	RecoveryNetworkOutageDaemonSetNamespace     = "default"
+	RecoveryNetworkOutageDaemonSetNamespace     = "ptp-network-outage-recovery"
 	RecoveryNetworkOutageDaemonSetName          = "ptp-network-outage-recovery"
 	RecoveryNetworkOutageDaemonSetContainerName = "container-00"
 )

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -259,7 +259,7 @@ func RecoverySlaveNetworkOutage(fullConfig testconfig.TestConfig, skippedInterfa
 			toggleNetworkInterface(outageRecoveryDaemonsetPod, ptpNodeInterface, slavePodNodeName, fullConfig)
 		}
 	}
-	DeletePtpTestPrivilegedDaemonSet(pkg.RecoveryNetworkOutageDaemonSetName, pkg.RecoveryNetworkOutageDaemonSetNamespace)
+	k8sPriviledgedDs.DeleteNamespaceIfPresent(pkg.RecoveryNetworkOutageDaemonSetNamespace)
 	logrus.Info("Recovery PTP outage ends ...........")
 }
 
@@ -333,7 +333,7 @@ func RebootSlaveNode(fullConfig testconfig.TestConfig) {
 	CheckSlaveSyncWithMaster(fullConfig)
 
 	// 5. Delete the reboot ptp test priviledged daemonset
-	DeletePtpTestPrivilegedDaemonSet(pkg.RebootDaemonSetName, pkg.RebootDaemonSetNamespace)
+	k8sPriviledgedDs.DeleteNamespaceIfPresent(pkg.RebootDaemonSetNamespace)
 
 	logrus.Info("Rebooting system ends ..............")
 }


### PR DESCRIPTION
This is to fix 2 calls to the updated privileged-daemonset where the namespace must not be default that we missed in previous PR