### PR TITLE
Improvements and bugfix (events buffer, corner case bug, better logs )

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/redhat-cne/sdk-go v0.1.1-0.20221202175356-6d25e1b3c0be
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/test-network-function/graphsolver-lib v0.0.2
+	github.com/test-network-function/graphsolver-lib v0.0.3
 	github.com/test-network-function/l2discovery-exports v0.0.3
 	github.com/test-network-function/l2discovery-lib v0.0.9
 	github.com/test-network-function/privileged-daemonset v1.0.2
@@ -101,7 +101,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/redhat-cne/channel-pubsub v0.0.7 // indirect
+	github.com/redhat-cne/channel-pubsub v0.0.8 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/test-network-function/graphsolver-exports v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -585,8 +585,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/channel-pubsub v0.0.7 h1:Ynr4Op3NIlwZs+9KreD13qtBwQoP9E3sS6dKSj2JwYU=
-github.com/redhat-cne/channel-pubsub v0.0.7/go.mod h1:mzF6XIdwFXrQ0JmvVA4UtflirDIM+q9Dj/1YGevGnOU=
+github.com/redhat-cne/channel-pubsub v0.0.8 h1:5UzwMev+pjIIfzHDyCsx8HlG4a/ahHpRO+EXMFDa7YQ=
+github.com/redhat-cne/channel-pubsub v0.0.8/go.mod h1:mzF6XIdwFXrQ0JmvVA4UtflirDIM+q9Dj/1YGevGnOU=
 github.com/redhat-cne/ptp-listener-exports v0.0.7 h1:OndW4kSKym5LK9bbEqJPE/LW/LGMDPw5IzXdmrGMRhI=
 github.com/redhat-cne/ptp-listener-exports v0.0.7/go.mod h1:oDdWZOsl2wP1WUECbyLvva0ld/JOvWzNWLJOSCOlOAI=
 github.com/redhat-cne/ptp-listener-lib v0.1.6 h1:HP5ckt7LaHHRKYMC/oYnc7e6F3ssG5XDXSQyblS2O04=
@@ -653,8 +653,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/test-network-function/graphsolver-exports v0.0.1 h1:27zhW/1fiKf3+NJsevl+jvuJu9t/MqOs1wmAkcmp8ng=
 github.com/test-network-function/graphsolver-exports v0.0.1/go.mod h1:Zo5bUPq3s1KWfz6MtMHzHQh1mSiW4DOpBbZ03TG2zIw=
-github.com/test-network-function/graphsolver-lib v0.0.2 h1:s/2petXZPAlG7Gh7ra7hi8Y2W0jv83LQMVJEUScwiYk=
-github.com/test-network-function/graphsolver-lib v0.0.2/go.mod h1:X9HIBAST5obDb8YMWykMIOU9iwouT2wrR1yLpTRmXQM=
+github.com/test-network-function/graphsolver-lib v0.0.3 h1:4gdxyqfZBfWOfi7lJOV+ZhlCsELOoQvV9Ji6HoidXnY=
+github.com/test-network-function/graphsolver-lib v0.0.3/go.mod h1:QfXYYotdpHkIaaSO+SPWyPDpt8SpeQWoiN9WnU5fmIE=
 github.com/test-network-function/l2discovery-exports v0.0.3 h1:kuzpWu5UQL3VIG+8AkjmsghkjZN1X3k3dQ8M36DsJc4=
 github.com/test-network-function/l2discovery-exports v0.0.3/go.mod h1:38JgpFHXB9PQ+4bPZQ+STsUKK9BrTe+5uDq47OeMV50=
 github.com/test-network-function/l2discovery-lib v0.0.9 h1:eDBxPzQs2Wd7deeELwjxNznwbHRLBNIV2yGljGGfcHk=

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -345,10 +345,11 @@ var _ = Describe("[ptp]", Serial, func() {
 					grandmasterID = &aString
 					Expect(err).To(BeNil())
 				}
-				ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID)
-
+				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID)
+				Expect(err).To(BeNil())
 				if fullConfig.PtpModeDiscovered == testconfig.DualNICBoundaryClock {
-					ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig), grandmasterID)
+					err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig), grandmasterID)
+					Expect(err).To(BeNil())
 				}
 			})
 
@@ -377,15 +378,16 @@ var _ = Describe("[ptp]", Serial, func() {
 				aLabel := pkg.PtpClockUnderTestNodeLabel
 				masterIDBc1, err := ptphelper.GetClockIDMaster(pkg.PtpBcMaster1PolicyName, &aLabel, nil)
 				Expect(err).To(BeNil())
-				ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredSlave1PtpConfig), &masterIDBc1)
-
+				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredSlave1PtpConfig), &masterIDBc1)
+				Expect(err).To(BeNil())
 				if fullConfig.PtpModeDiscovered == testconfig.DualNICBoundaryClock &&
 					fullConfig.FoundSolutions[testconfig.AlgoDualNicBCWithSlavesString] {
 
 					aLabel := pkg.PtpClockUnderTestNodeLabel
 					masterIDBc2, err := ptphelper.GetClockIDMaster(pkg.PtpBcMaster2PolicyName, &aLabel, nil)
 					Expect(err).To(BeNil())
-					ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredSlave2PtpConfig), &masterIDBc2)
+					err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredSlave2PtpConfig), &masterIDBc2)
+					Expect(err).To(BeNil())
 				}
 
 			})
@@ -442,7 +444,8 @@ var _ = Describe("[ptp]", Serial, func() {
 						grandmasterID = &aString
 						Expect(err).To(BeNil())
 					}
-					ptptesthelper.BasicClockSyncCheck(fullConfig, modifiedPtpConfig, grandmasterID)
+					err = ptptesthelper.BasicClockSyncCheck(fullConfig, modifiedPtpConfig, grandmasterID)
+					Expect(err).To(BeNil())
 				})
 
 				By("Deleting the test profile", func() {

--- a/test/pkg/logging/logging.go
+++ b/test/pkg/logging/logging.go
@@ -1,7 +1,12 @@
 package logging
 
 import (
+	"fmt"
 	"os"
+	"path"
+	"runtime"
+	"strconv"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -20,4 +25,20 @@ func InitLogLevel() {
 
 	logrus.Info("Log level set to: ", logLevel)
 	logrus.SetLevel(logLevel)
+	SetLogFormat()
+}
+
+// SetLogFormat sets the log format for logrus
+func SetLogFormat() {
+	customFormatter := new(logrus.TextFormatter)
+	customFormatter.TimestampFormat = time.StampMilli
+	customFormatter.PadLevelText = true
+	customFormatter.FullTimestamp = true
+	customFormatter.ForceColors = true
+	logrus.SetReportCaller(true)
+	customFormatter.CallerPrettyfier = func(f *runtime.Frame) (string, string) {
+		_, filename := path.Split(f.File)
+		return strconv.Itoa(f.Line) + "]", fmt.Sprintf("[%s:", filename)
+	}
+	logrus.SetFormatter(customFormatter)
 }

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -185,10 +185,11 @@ func CheckSlaveSyncWithMaster(fullConfig testconfig.TestConfig) {
 			logrus.Warnf("could not determine the Grandmaster ID (probably because the log no longer exists), err=%s", err)
 		}
 	}
-	BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID)
-
+	err = BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID)
+	Expect(err).NotTo(HaveOccurred())
 	if fullConfig.PtpModeDiscovered == testconfig.DualNICBoundaryClock {
-		BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig), grandmasterID)
+		err = BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig), grandmasterID)
+		Expect(err).NotTo(HaveOccurred())
 	}
 }
 

--- a/vendor/github.com/redhat-cne/channel-pubsub/pubsublib.go
+++ b/vendor/github.com/redhat-cne/channel-pubsub/pubsublib.go
@@ -13,8 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const channelBuffer = 10
-
 type Pubsub struct {
 	mu     sync.RWMutex
 	subs   map[string][]chan exports.StoredEvent
@@ -28,7 +26,7 @@ func NewPubsub() *Pubsub {
 	return ps
 }
 
-func (ps *Pubsub) Subscribe(topic string) (chin <-chan exports.StoredEvent, subscriberID int) {
+func (ps *Pubsub) Subscribe(topic string, channelBuffer int) (chin <-chan exports.StoredEvent, subscriberID int) {
 	ps.mu.Lock()
 	logrus.Debugf("lock Subscribe %s", topic)
 	defer logrus.Debugf("unlock Subscribe %s", topic)
@@ -53,6 +51,7 @@ func (ps *Pubsub) Publish(topic string, msg exports.StoredEvent) {
 		if ch == nil {
 			continue
 		}
+		logrus.Debugf("Publish topic=%s channel len=%d, capacity=%d", topic, len(ch), cap(ch))
 		ch <- msg
 	}
 }

--- a/vendor/github.com/test-network-function/graphsolver-lib/.golangci.yml
+++ b/vendor/github.com/test-network-function/graphsolver-lib/.golangci.yml
@@ -122,6 +122,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.50.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.51.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/vendor/github.com/test-network-function/graphsolver-lib/lib.go
+++ b/vendor/github.com/test-network-function/graphsolver-lib/lib.go
@@ -159,7 +159,7 @@ func PermutationsWithConstraints(config export.L2Info, algo [][][]int, l []int, 
 		temp := make([]int, 0)
 		temp = append(temp, l...)
 		temp = temp[0:e]
-		logrus.Debugf("%v --  %v", temp, result)
+		logrus.Tracef("Permutations %v --  %v", temp, result)
 		*solutions = append(*solutions, temp)
 	} else {
 		// Backtracking loop

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -281,7 +281,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/channel-pubsub v0.0.7
+# github.com/redhat-cne/channel-pubsub v0.0.8
 ## explicit; go 1.19
 github.com/redhat-cne/channel-pubsub
 # github.com/redhat-cne/ptp-listener-exports v0.0.7
@@ -314,8 +314,8 @@ github.com/stretchr/testify/assert
 # github.com/test-network-function/graphsolver-exports v0.0.1
 ## explicit; go 1.19
 github.com/test-network-function/graphsolver-exports
-# github.com/test-network-function/graphsolver-lib v0.0.2
-## explicit; go 1.19
+# github.com/test-network-function/graphsolver-lib v0.0.3
+## explicit; go 1.20
 github.com/test-network-function/graphsolver-lib
 # github.com/test-network-function/l2discovery-exports v0.0.3
 ## explicit; go 1.20


### PR DESCRIPTION
**Increase event buffering and improve logs:** The previous buffer size for incoming events was set to 10 previously which is not enough in case the events are received rapidly, for instance if a clock state updates too rapidly. The buffer size is now increased to hold 100 events. Also, instead of being a constant, the value for the allocated buffer is now a parameter of the event subscription.
**Fix no error returned when clock is not in sync:** Error returned by the BasicClockSyncCheck function were not check leading to test cases passing were they should have failed.
**Better logs:** improved the log format to match the one used in https://github.com/test-network-function/cnf-certification-test