### PR TITLE
OCPBUGS-13884: fix must-gather base image

### DIFF
--- a/must-gather/Dockerfile.rhel7
+++ b/must-gather/Dockerfile.rhel7
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS 
 WORKDIR /go/src/github.com/openshift/ptp-operator/must-gather
 COPY . .
 
-FROM registry.ci.openshift.org/ocp/4.13:base
+FROM registry.ci.openshift.org/ocp/4.13:must-gather
 LABEL io.k8s.display-name="ptp-operator-must-gather" \
       io.k8s.description="This is a PTP must-gather image that collectes PTP operator related resources."
 COPY --from=builder /go/src/github.com/openshift/ptp-operator/must-gather/collection-scripts/* /usr/bin/


### PR DESCRIPTION
This commit fixes must-gather by relying on a different base image. The original image did not have oc binary in it, so all the oc adm inspect commands were failing.

This is a backport of https://github.com/openshift/ptp-operator/pull/349