### PR TITLE
fix Dockerfile for golang-1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.20 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/ptp-operator
 COPY . .
 ENV GO111MODULE=off
 RUN make
 
-FROM quay.io/openshift/origin-base:4.14
+FROM registry.ci.openshift.org/ocp/4.14:base
 COPY --from=builder /go/src/github.com/openshift/ptp-operator/build/_output/bin/ptp-operator /usr/local/bin/
 COPY --from=builder /go/src/github.com/openshift/ptp-operator/manifests /manifests
 COPY bindata /bindata

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,10 +1,10 @@
-FROM docker.io/library/golang:1.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/ptp-operator
 COPY . .
 ENV GO111MODULE=off
 RUN make
 
-FROM quay.io/openshift/origin-base:4.13
+FROM registry.ci.openshift.org/ocp/4.14:base
 COPY --from=builder /go/src/github.com/openshift/ptp-operator/build/_output/bin/ptp-operator /usr/local/bin/
 COPY --from=builder /go/src/github.com/openshift/ptp-operator/manifests /manifests
 COPY bindata /bindata


### PR DESCRIPTION
The golang:1.20 image does not have CGO libraries enabled (CGO_ENABLED=1) so the image will be compiled without c libraries and fail to launch pod.

```
$ oc get pods
NAME                            READY   STATUS             RESTARTS      AGE ptp-operator-84c896d568-q725f   0/1     CrashLoopBackOff   6 (22s ago)   6m19s

$ oc logs -f ptp-operator-84c896d568-q725f
ptp-operator: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ptp-operator)
ptp-operator: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by ptp-operator)
```