### PR TITLE
CNF-9844: increase timeout for outage recovery test to avoid spurious failures

### DIFF
--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -263,7 +263,7 @@ func RecoverySlaveNetworkOutage(fullConfig testconfig.TestConfig, skippedInterfa
 func toggleNetworkInterface(pod corev1.Pod, interfaceName string, slavePodNodeName string, fullConfig testconfig.TestConfig) {
 
 	const (
-		waitingPeriod      = 4 * time.Minute
+		waitingPeriod      = 5 * time.Minute
 		offsetRetryCounter = 5
 	)
 	By("Setting interface down then wait")


### PR DESCRIPTION
also addresses: [CNF-9845](https://issues.redhat.com//browse/CNF-9845)