### PR TITLE
[release-4.12]  OCPBUGS-20185: ptp4l process restarted unexpected with dual NIC boundary clocks configured

### DIFF
--- a/controllers/recommend.go
+++ b/controllers/recommend.go
@@ -55,7 +55,6 @@ func getRecommendProfiles(ptpConfigList *ptpv1.PtpConfigList, node corev1.Node) 
 
 	profilesNames := getRecommendProfilesNames(ptpConfigList, node)
 	glog.V(2).Infof("recommended ptp profiles names are %v for node: %s", returnMapKeys(profilesNames), node.Name)
-
 	profiles := []ptpv1.PtpProfile{}
 	for _, cfg := range ptpConfigList.Items {
 		if cfg.Spec.Profile != nil {
@@ -66,10 +65,14 @@ func getRecommendProfiles(ptpConfigList *ptpv1.PtpConfigList, node corev1.Node) 
 			}
 		}
 	}
-
 	if len(profiles) != len(profilesNames) {
 		return nil, fmt.Errorf("failed to find all the profiles")
 	}
+	// sort profiles by name
+	sort.SliceStable(profiles, func(i, j int) bool {
+		return *profiles[i].Name < *profiles[j].Name
+	})
+
 	return profiles, nil
 }
 


### PR DESCRIPTION
fix restart of process due to non deterministic order of profile name on  each reconcile