### PR TITLE
[release-4.14] Bug OCPBUGS-22695: fix SNO lease duration and restore namespace

### DIFF
--- a/test/validation/tests/validation.go
+++ b/test/validation/tests/validation.go
@@ -51,6 +51,10 @@ var _ = Describe("validation", func() {
 			}, testutils.TimeoutIn10Minutes, testutils.TimeoutInterval2Seconds).ShouldNot(HaveOccurred())
 		})
 
+		It("should set the lease duration to 270 seconds for SNO, 137 seconds otherwise", func() {
+			ptphelper.CheckLeaseDuration(testutils.PtpNamespace, 137, 270)
+		})
+
 		It("should have the linuxptp daemonset in running state", func() {
 			ptphelper.WaitForPtpDaemonToBeReady()
 		})


### PR DESCRIPTION
The leaseDurationSeconds should be 270 seconds for SNO. Add back namespace to be consistent with previous releases.