### PR TITLE
Increase PrometheusQueryRetries to 30

### DIFF
--- a/test/pkg/metrics/prometheus.go
+++ b/test/pkg/metrics/prometheus.go
@@ -22,7 +22,7 @@ const (
 	prometheusResponseSuccess    = "success"
 	kubeletServiceMonitor        = "kubelet"
 
-	PrometheusQueryRetries       = 10
+	PrometheusQueryRetries       = 30
 	PrometheusQueryRetryInterval = 1 * time.Second
 )
 


### PR DESCRIPTION
Sometimes seeing test failures because of failing to query Prometheus.  Increasing the retries alleviates those failures.