### PR TITLE
Increase PrometheusQueryRetries from 30 to 60

### DIFF
--- a/test/pkg/metrics/prometheus.go
+++ b/test/pkg/metrics/prometheus.go
@@ -22,7 +22,7 @@ const (
 	prometheusResponseSuccess    = "success"
 	kubeletServiceMonitor        = "kubelet"
 
-	PrometheusQueryRetries       = 30
+	PrometheusQueryRetries       = 60
 	PrometheusQueryRetryInterval = 1 * time.Second
 )
 


### PR DESCRIPTION
Still getting timeouts on CI at 30 seconds.  Increase to 60.