### PR TITLE
OCPBUGS-29634: fix ci issues

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -1,10 +1,30 @@
 #!/bin/bash
 set -x
-# Install Go 1.20.4
-wget https://go.dev/dl/go1.20.4.linux-amd64.tar.gz
-rm -rf /usr/local/go
-tar -C /usr/local -xzf go1.20.4.linux-amd64.tar.gz
-export PATH=$PATH:/usr/local/go/bin
+
+# make sure the test runs with specific go vervsion.
+# install go in <ptp-operator-repo>/bin if not already installed
+GO_VERSION=1.20.4
+REPO_BIN_PATH=$(pwd)/bin
+echo "REPO_BIN_PATH is ${REPO_BIN_PATH}"
+export PATH="${REPO_BIN_PATH}/go/bin:$PATH"
+if go version | grep -q "${GO_VERSION}"; then
+	echo "Go ${GO_VERSION} is already installed."
+else
+	# Check the operating system type
+	if [[ "$(uname)" == "Darwin" ]]; then
+		# macOS
+		GO_BINARY="go${GO_VERSION}.darwin-amd64.tar.gz"
+	elif [[ "$(uname)" == "Linux" ]]; then
+		GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz"
+	else
+		echo "Unsupported operating system $(uname)."
+		exit 1
+	fi
+	temp_dir=$(mktemp -d)
+	wget https://go.dev/dl/${GO_BINARY} -P "$temp_dir"
+	tar -C ${REPO_BIN_PATH} -xzf "$temp_dir/${GO_BINARY}"
+	rm -rf "$temp_dir"
+fi
 
 which ginkgo
 if [ $? -ne 0 ]; then

--- a/test/conformance/parallel/ptp.go
+++ b/test/conformance/parallel/ptp.go
@@ -166,15 +166,27 @@ func testPtpCpuUtilization(fullConfig testconfig.TestConfig, testParameters *ptp
 	// Make sure the configured time interval for prometheus's rate() func is at least twice
 	// the current scrape interval for the kubelet's cadvisor endpoint. Otherwise, rate() will
 	// never get the minimum samples number (2) to work.
-	Expect(int(prometheusRateTimeWindow.Seconds())).To(BeNumerically(">=", 2*cadvisorScrapeInterval),
-		fmt.Sprintf("configured time window (%s) is lower than twice the cadvisor scraping interval (%d secs)",
-			prometheusRateTimeWindow, cadvisorScrapeInterval))
+	if int(prometheusRateTimeWindow.Seconds()) < 2*cadvisorScrapeInterval {
+		// add extra 10 seconds as a safeguard
+		timeAdjusted := fmt.Sprintf("%ds", 2*cadvisorScrapeInterval+10)
+		logrus.Infof("configured time window (%s) is lower than twice the cadvisor scraping interval (%d secs). Adjusted to (%s).",
+			prometheusRateTimeWindow, cadvisorScrapeInterval, timeAdjusted)
+		prometheusRateTimeWindow, _ = time.ParseDuration(timeAdjusted)
+	}
 
 	// Warmup: waiting until prometheus can scrape a couple of cpu samples from ptp pods.
-	warmupTime := time.Duration(2*cadvisorScrapeInterval) * time.Second
-	By(fmt.Sprintf("Waiting %s so prometheus can get at least 2 metric samples from the ptp pods.", warmupTime))
+	time.Sleep(prometheusRateTimeWindow)
 
-	time.Sleep(warmupTime)
+	// Trial run to see if prometheus metrics is ready. If not wait for up to 10 minutes.
+	for i := 0; i < 10; i++ {
+		_, err = isCpuUsageThresholdReachedInPtpPods(prometheusPod, ptpPodsPerNode, &params, prometheusRateTimeWindow)
+		if err != nil {
+			logrus.Infof("Prometheus metrics is not ready. Wait for one more minutes")
+			time.Sleep(time.Minute)
+		} else {
+			break
+		}
+	}
 
 	// Create timer channel for test case timeout.
 	testCaseDuration := time.Duration(params.CpuTestSpec.Duration) * time.Minute
@@ -195,7 +207,7 @@ func testPtpCpuUtilization(fullConfig testconfig.TestConfig, testParameters *ptp
 		case <-cpuUsageCheckTicker.C:
 			logrus.Infof("Retrieving cpu usage of the ptp pods.")
 
-			thresholdReached, err := isCpuUsageThresholdReachedInPtpPods(prometheusPod, ptpPodsPerNode, &params)
+			thresholdReached, err := isCpuUsageThresholdReachedInPtpPods(prometheusPod, ptpPodsPerNode, &params, prometheusRateTimeWindow)
 			logrus.Infof("Cpu usage threshold reached: %v", thresholdReached)
 			Expect(err).To(BeNil(), "failed to get cpu usage")
 
@@ -210,11 +222,8 @@ func testPtpCpuUtilization(fullConfig testconfig.TestConfig, testParameters *ptp
 
 // isCpuUsageThresholdReachedInPtpPods is a helper that checks whether the cpu usage of
 // each node, pod and or container is below preconfigured (via yaml) threshold/s.
-func isCpuUsageThresholdReachedInPtpPods(prometheusPod *v1core.Pod, ptpPodsPerNode map[string][]*v1core.Pod, cpuTestConfig *ptptestconfig.CpuUtilization) (bool, error) {
+func isCpuUsageThresholdReachedInPtpPods(prometheusPod *v1core.Pod, ptpPodsPerNode map[string][]*v1core.Pod, cpuTestConfig *ptptestconfig.CpuUtilization, rateTimeWindow time.Duration) (bool, error) {
 	thresholdReached := false
-
-	// No need to check error for the rateTimeWindow: it was already checked.
-	rateTimeWindow, _ := cpuTestConfig.PromRateTimeWindow()
 
 	checkNodeTotalCpuUsage, nodeCpuUsageThreshold := cpuTestConfig.ShouldCheckNodeTotalCpuUsage()
 

--- a/test/conformance/serial/prometheus.go
+++ b/test/conformance/serial/prometheus.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/ptp-operator/test/pkg/client"
 	"github.com/openshift/ptp-operator/test/pkg/metrics"
 	"github.com/openshift/ptp-operator/test/pkg/pods"
+	"github.com/sirupsen/logrus"
 
 	k8sv1 "k8s.io/api/core/v1"
 )
@@ -46,12 +47,26 @@ func collectPrometheusMetrics(uniqueMetricKeys []string) map[string][]string {
 	Expect(err).ToNot(HaveOccurred(), "failed to get prometheus pod")
 
 	podsPerPrometheusMetricKey := map[string][]string{}
+	isFirstQuery := true
 	for _, metricsKey := range uniqueMetricKeys {
 		promResult := []result{}
 		promResponse := metrics.PrometheusQueryResponse{}
 		promResponse.Data.Result = &promResult
 
-		err := metrics.RunPrometheusQuery(prometheusPod, metricsKey, &promResponse)
+		// Trial run to see if prometheus metrics is ready. If not wait for up to 10 minutes.
+		if isFirstQuery {
+			for i := 0; i < 10; i++ {
+				err = metrics.RunPrometheusQuery(prometheusPod, metricsKey, &promResponse)
+				if err != nil {
+					logrus.Infof("Prometheus metrics is not ready. Wait for one more minutes")
+					time.Sleep(time.Minute)
+				} else {
+					isFirstQuery = false
+					break
+				}
+			}
+		}
+		err = metrics.RunPrometheusQuery(prometheusPod, metricsKey, &promResponse)
 		Expect(err).ToNot(HaveOccurred(), "failed to run prometheus query")
 
 		podsPerKey := []string{}

--- a/test/pkg/clean/clean.go
+++ b/test/pkg/clean/clean.go
@@ -65,7 +65,7 @@ func Configs() {
 			ptpConfig.Name == pkg.PtpTempPolicyName {
 			err = client.Client.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Delete(context.Background(), ptpConfig.Name, metav1.DeleteOptions{})
 			if err != nil {
-				logrus.Errorf("clean.All: Failed to delete ptp config %s %v", ptpConfig.Name, err)
+				logrus.Infof("clean.All: Failed to delete ptp config %s %v", ptpConfig.Name, err)
 			}
 		}
 	}

--- a/test/pkg/event/event.go
+++ b/test/pkg/event/event.go
@@ -143,8 +143,15 @@ func CreateEventProxySidecar(nodeNameFull string) (err error) {
 		logrus.Infof("namespace %s deleted", ConsumerSidecarTestNamespace)
 	}
 
+	labels := map[string]string{
+		"security.openshift.io/scc.podSecurityLabelSync": "false",
+		"pod-security.kubernetes.io/audit":               "privileged",
+		"pod-security.kubernetes.io/enforce":             "privileged",
+		"pod-security.kubernetes.io/warn":                "privileged",
+		"openshift.io/cluster-monitoring":                "true",
+	}
 	// create sidecar namespace
-	err = namespaces.Create(ConsumerSidecarTestNamespace, client.Client)
+	err = namespaces.Create(ConsumerSidecarTestNamespace, client.Client, labels)
 	if err != nil {
 		return fmt.Errorf("could not create namespace=%s, err=%s", ConsumerSidecarTestNamespace, err)
 	}

--- a/test/pkg/logging/logging.go
+++ b/test/pkg/logging/logging.go
@@ -9,10 +9,13 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func InitLogLevel() {
 	logLevelString, isSet := os.LookupEnv("PTP_LOG_LEVEL")
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	var logLevel, err = logrus.ParseLevel(logLevelString)
 	if err != nil {
 		logrus.Error("PTP_LOG_LEVEL environment set with an invalid value, defaulting to INFO \n Valid values are:  trace, debug, info, warn, error, fatal, panic")

--- a/test/pkg/metrics/prometheus.go
+++ b/test/pkg/metrics/prometheus.go
@@ -22,7 +22,7 @@ const (
 	prometheusResponseSuccess    = "success"
 	kubeletServiceMonitor        = "kubelet"
 
-	PrometheusQueryRetries       = 60
+	PrometheusQueryRetries       = 10
 	PrometheusQueryRetryInterval = 1 * time.Second
 )
 

--- a/test/pkg/namespaces/namespaces.go
+++ b/test/pkg/namespaces/namespaces.go
@@ -29,10 +29,11 @@ func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Durat
 
 // Create creates a new namespace with the given name.
 // If the namespace exists, it returns.
-func Create(namespace string, cs *testclient.ClientSet) error {
+func Create(namespace string, cs *testclient.ClientSet, labels map[string]string) error {
 	_, err := cs.CoreV1().Namespaces().Create(context.Background(), &k8sv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name:   namespace,
+			Labels: labels,
 		}},
 		metav1.CreateOptions{},
 	)

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -374,68 +374,6 @@ func GetPtpPodsPerNode() (map[string][]*corev1.Pod, error) {
 	return podsPerNode, nil
 }
 
-// GetPodsTotalCpuUsage uses prometheus metric "container_cpu_usage_seconds_total"
-// to return the total cpu usage by all the given pods.
-// As each query needs to be done inside one of the prometheus pods, an optional
-// param prometheusPod can be set for that purpose. If it's nil, the function
-// will try to get it on every call.
-func GetPodsTotalCpuUsage(pods []*corev1.Pod, prometheusPod *corev1.Pod) (float64, error) {
-	const (
-		// To make sure that prometheus can use rate() with at least two samples,
-		// we should use at least two sampling periods (2 * 30s = 60). We'll add 10
-		// extra seconds as a safeguard.
-		timeWindow = 70 * time.Second
-		// queryFormat params: pod name & time window.
-		queryFormat = `rate(container_cpu_usage_seconds_total{container="", pod="%s"}[%s])`
-	)
-
-	if prometheusPod == nil {
-		logrus.Debugf("Getting prometheus pod...")
-		var err error
-		prometheusPod, err = metrics.GetPrometheusPod()
-		if err != nil {
-			return 0, fmt.Errorf("failed to get prometheus pod: %w", err)
-		}
-	}
-
-	queryTimeWindow := time.Duration(timeWindow).String()
-	totalCpu := float64(0)
-	for _, pod := range pods {
-		query := fmt.Sprintf(queryFormat, pod.Name, queryTimeWindow)
-
-		// Preparing the result part so the unmarshaller can set it accordingly.
-		resultVector := metrics.PrometheusVectorResult{}
-		promResponse := metrics.PrometheusQueryResponse{}
-		promResponse.Data.Result = &resultVector
-
-		err := metrics.RunPrometheusQueryWithRetries(prometheusPod, query, metrics.PrometheusQueryRetries, metrics.PrometheusQueryRetryInterval, &promResponse, func(*metrics.PrometheusQueryResponse) bool {
-			// Make sure the result's value is not empty
-			logrus.Infof("Checking result vector len: %v", len(resultVector))
-			if len(resultVector) != 1 {
-				logrus.Infof("Invalid result vector length in prometheus response: %+v", promResponse)
-				return false
-			}
-			return true
-		})
-
-		if err != nil {
-			return 0, fmt.Errorf("prometheus query failure: %w", err)
-		}
-
-		// The rate query should return only one metric, so it's safe to access the first result.
-		podCpuUsage, tsMillis, err := metrics.GetPrometheusResultFloatValue(resultVector[0].Value)
-		if err != nil {
-			return 0, fmt.Errorf("failed to get value from prometheus response from pod %s (ns %s): %w", pod.Name, pod.Namespace, err)
-		}
-
-		logrus.Debugf("Pod %s (ns %s) cpu usage: %v (ts: %s)", pod.Name, pod.Namespace, podCpuUsage, time.UnixMilli(tsMillis).String())
-
-		totalCpu += podCpuUsage
-	}
-
-	return totalCpu, nil
-}
-
 // GetPodTotalCpuUsage uses prometheus metric "container_cpu_usage_seconds_total"
 // to return the total cpu usage by all the given pods.
 // As each query needs to be done inside one of the prometheus pods, an optional


### PR DESCRIPTION
- Add pod-security labels to consumer sidecar test namespace.
- Add SetLogger to avoid exception during logging.
- Add prometheus trial poll and wait for 1-10 minutes for the metrics to be ready if the poll fail.
- Adjust prometheus rate time window in relation to cadvisor scrape interval to make sure minimal samples can be scraped.