### PR TITLE
OCPBUGS-29634: fix CPU Utilization soak test

### DIFF
--- a/test/conformance/config/ptptestconfig.yaml
+++ b/test/conformance/config/ptptestconfig.yaml
@@ -42,4 +42,4 @@ soaktest:
           - pod_type: "linuxptp-daemon"
             container: "linuxptp-daemon-container"
             cpu_threshold_mcores: 40
-    desc: "The test measures PTP CPU usage and fails if >15mcores"
+    desc: "The test measures PTP CPU usage and fails if > cpu_threshold_mcores"

--- a/test/conformance/parallel/ptp.go
+++ b/test/conformance/parallel/ptp.go
@@ -64,7 +64,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-parallel]", func() 
 
 	Context("Event based tests", func() {
 		BeforeEach(func() {
-
 			if !ptphelper.PtpEventEnabled() {
 				Skip("Skipping, PTP events not enabled")
 			}
@@ -75,7 +74,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-parallel]", func() 
 		})
 
 		It("PTP Slave Clock Sync", func() {
-
 			testPtpSlaveClockSync(fullConfig, testParameters) // Implementation of the test case
 
 		})
@@ -177,17 +175,6 @@ func testPtpCpuUtilization(fullConfig testconfig.TestConfig, testParameters *ptp
 	// Warmup: waiting until prometheus can scrape a couple of cpu samples from ptp pods.
 	time.Sleep(prometheusRateTimeWindow)
 
-	// Trial run to see if prometheus metrics is ready. If not wait for up to 10 minutes.
-	for i := 0; i < 10; i++ {
-		_, err = isCpuUsageThresholdReachedInPtpPods(prometheusPod, ptpPodsPerNode, &params, prometheusRateTimeWindow)
-		if err != nil {
-			logrus.Infof("Prometheus metrics is not ready. Wait for one more minutes")
-			time.Sleep(time.Minute)
-		} else {
-			break
-		}
-	}
-
 	// Create timer channel for test case timeout.
 	testCaseDuration := time.Duration(params.CpuTestSpec.Duration) * time.Minute
 	tcEndChan := time.After(testCaseDuration)
@@ -255,17 +242,16 @@ func isCpuUsageThresholdReachedInPtpPods(prometheusPod *v1core.Pod, ptpPodsPerNo
 
 			for i := range pod.Spec.Containers {
 				container := &pod.Spec.Containers[i]
-				cpuUsage, err := ptptesthelper.GetContainerCpuUsage(pod.Name, container.Name, pod.Namespace, rateTimeWindow, prometheusPod)
-				if err != nil {
-					return false, fmt.Errorf("failed to get total cpu usage for ptp pods on node %s: %w", nodeName, err)
-				}
-
-				logrus.Infof("Node %s: pod: %s, container: %s (ns:%s) cpu usage: %.5f", nodeName, pod.Name, container.Name, pod.Namespace, cpuUsage)
 
 				// Should we check the total cpu usage for this container?
 				checkCpuUsage, cpuUsageThreshold := cpuTestConfig.ShouldCheckContainerCpuUsage(pod.Name, container.Name)
 				if !checkCpuUsage {
 					continue
+				}
+
+				cpuUsage, err := ptptesthelper.GetContainerCpuUsage(pod.Name, container.Name, pod.Namespace, rateTimeWindow, prometheusPod)
+				if err != nil {
+					return false, fmt.Errorf("failed to get total cpu usage for ptp pods on node %s: %w", nodeName, err)
 				}
 
 				logrus.Debugf("Checking cpu usage of container %s (pod %s). Cpu Usage: %.5f - Threshold: %.5f", container.Name, pod.Name, cpuUsage, cpuUsageThreshold)

--- a/test/conformance/serial/prometheus.go
+++ b/test/conformance/serial/prometheus.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/ptp-operator/test/pkg/client"
 	"github.com/openshift/ptp-operator/test/pkg/metrics"
 	"github.com/openshift/ptp-operator/test/pkg/pods"
-	"github.com/sirupsen/logrus"
 
 	k8sv1 "k8s.io/api/core/v1"
 )
@@ -47,26 +46,12 @@ func collectPrometheusMetrics(uniqueMetricKeys []string) map[string][]string {
 	Expect(err).ToNot(HaveOccurred(), "failed to get prometheus pod")
 
 	podsPerPrometheusMetricKey := map[string][]string{}
-	isFirstQuery := true
 	for _, metricsKey := range uniqueMetricKeys {
 		promResult := []result{}
 		promResponse := metrics.PrometheusQueryResponse{}
 		promResponse.Data.Result = &promResult
 
-		// Trial run to see if prometheus metrics is ready. If not wait for up to 10 minutes.
-		if isFirstQuery {
-			for i := 0; i < 10; i++ {
-				err = metrics.RunPrometheusQuery(prometheusPod, metricsKey, &promResponse)
-				if err != nil {
-					logrus.Infof("Prometheus metrics is not ready. Wait for one more minutes")
-					time.Sleep(time.Minute)
-				} else {
-					isFirstQuery = false
-					break
-				}
-			}
-		}
-		err = metrics.RunPrometheusQuery(prometheusPod, metricsKey, &promResponse)
+		err := metrics.RunPrometheusQuery(prometheusPod, metricsKey, &promResponse)
 		Expect(err).ToNot(HaveOccurred(), "failed to run prometheus query")
 
 		podsPerKey := []string{}


### PR DESCRIPTION
Remove trial prometheus queries.

Check container cpu usage only if a threshold target for this container is set in the test config. This reduces the number of prometheus queries significantly and avoid queries for kube-rbac-proxy and pause containers.

When retry prometheus queries, increase the rateTimeWindow by 10 seconds with each retry to avoid returning empty data due to not enough samples being captured within the window.