### PR TITLE
Add haprofiles to ptpSettings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,40 @@ In above examples, `profile1` will be applied by `linuxptp-daemon` to nodes labe
 
 `xxx-ptpconfig` CR is created with `PtpConfig` kind. `spec.profile` defines profile named `profile1` which contains `interface (enp134s0f0)` to run ptp4l process on, `ptp4lOpts (-s -2)` sysconfig options to run ptp4l process with and `phc2sysOpts (-a -r)` to run phc2sys process with. `spec.recommend` defines `priority` (lower numbers mean higher priority, 0 is the highest priority) and `match` rules of profile `profile1`. `priority` is useful when there are multiple `PtpConfig` CRs defined, linuxptp daemon applies `match` rules against node labels and names from high priority to low priority in order. If any of `nodeLabel` or `nodeName` on a specific node matches with the node label or name where daemon runs, it applies profile on that node.
 
+#### ptpConfig to enable High Availability for phc2sys by adding profiles of ptp4l enabled config's under `haProfiles`
+
+```
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+name: suppress-logs-ptpconfig
+namespace: openshift-ptp
+spec:
+phc2sysOpts: "-a -r"
+ptp4lOpts: " "
+profile:
+- name: "enable-ha"
+  ...
+  ...
+  ......
+  haProfiles:
+  - profile2
+  - profile1
+  ptpSettings:
+  stdoutFilter: "^.*delay   filtered.*$"
+  logReduce: "true"
+  recommend:
+- profile: "enable-ha"
+  priority: 4
+  match:
+    - nodeLabel: "node-role.kubernetes.io/worker"
+
+```
+Requirements:
+Two ptp4l configurations must exist with the phc2sysOPts field set to an empty string.
+The names of these ptp4l configurations will be used and listed under the haProfiles key in the phc2sys-only enabled ptpConfig.
+
+
 ## Quick Start
 
 To install PTP Operator:

--- a/api/v1/ptpconfig_types.go
+++ b/api/v1/ptpconfig_types.go
@@ -62,14 +62,15 @@ type PtpConfigList struct {
 }
 
 type PtpProfile struct {
-	Name        *string `json:"name"`
-	Interface   *string `json:"interface,omitempty"`
-	Ptp4lOpts   *string `json:"ptp4lOpts,omitempty"`
-	Phc2sysOpts *string `json:"phc2sysOpts,omitempty"`
-	Ts2PhcOpts  *string `json:"ts2phcOpts,omitempty"`
-	Ptp4lConf   *string `json:"ptp4lConf,omitempty"`
-	Phc2sysConf *string `json:"phc2sysConf,omitempty"`
-	Ts2PhcConf  *string `json:"ts2phcConf,omitempty"`
+	Name        *string   `json:"name"`
+	Interface   *string   `json:"interface,omitempty"`
+	Ptp4lOpts   *string   `json:"ptp4lOpts,omitempty"`
+	Phc2sysOpts *string   `json:"phc2sysOpts,omitempty"`
+	HaProfiles  []*string `json:"haProfiles,omitempty"`
+	Ts2PhcOpts  *string   `json:"ts2phcOpts,omitempty"`
+	Ptp4lConf   *string   `json:"ptp4lConf,omitempty"`
+	Phc2sysConf *string   `json:"phc2sysConf,omitempty"`
+	Ts2PhcConf  *string   `json:"ts2phcConf,omitempty"`
 	// +kubebuilder:validation:Enum=SCHED_OTHER;SCHED_FIFO;
 	PtpSchedulingPolicy *string `json:"ptpSchedulingPolicy,omitempty"`
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1/ptpconfig_webhook.go
+++ b/api/v1/ptpconfig_webhook.go
@@ -40,6 +40,7 @@ const (
 
 // log is for logging in this package.
 var ptpconfiglog = logf.Log.WithName("ptpconfig-resource")
+var profileRegEx = regexp.MustCompile(`^(\w+)(,\s*([\w-_]+))`)
 
 func (r *PtpConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -132,6 +133,10 @@ func (r *PtpConfig) validate() error {
 					v = strings.ToLower(v)
 					if v != "true" && v != "false" {
 						return errors.New("logReduce='" + v + "' is invalid; must be in 'true' or 'false'")
+					}
+				case k == "haProfiles":
+					if !profileRegEx.MatchString(v) {
+						return errors.New("haProfiles='" + v + "' is invalid; must be comma seperated profile names")
 					}
 				default:
 					return errors.New("profile.PtpSettings '" + k + "' is not a configurable setting")

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -495,6 +495,17 @@ func (in *PtpProfile) DeepCopyInto(out *PtpProfile) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.HaProfiles != nil {
+		in, out := &in.HaProfiles, &out.HaProfiles
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
 	if in.Ts2PhcOpts != nil {
 		in, out := &in.Ts2PhcOpts, &out.Ts2PhcOpts
 		*out = new(string)

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -383,7 +383,7 @@ spec:
                 - name: RELEASE_VERSION
                   value: v4.16.0
                 - name: LINUXPTP_DAEMON_IMAGE
-                  value: quay.io/openshift/origin-ptp:4.16
+                  value: quay.io/aneeshkp/linuxptp-daemon:416.ha18
                 - name: KUBE_RBAC_PROXY_IMAGE
                   value: quay.io/openshift/origin-kube-rbac-proxy:4.16
                 - name: SIDECAR_EVENT_IMAGE
@@ -394,7 +394,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-                image: quay.io/openshift/origin-ptp-operator:4.16
+                image: quay.io/aneeshkp/ptp-operator:416.ha1
                 imagePullPolicy: IfNotPresent
                 name: ptp-operator
                 ports:

--- a/bundle/manifests/ptp.openshift.io_ptpconfigs.yaml
+++ b/bundle/manifests/ptp.openshift.io_ptpconfigs.yaml
@@ -37,6 +37,10 @@ spec:
               profile:
                 items:
                   properties:
+                    haProfiles:
+                      items:
+                        type: string
+                      type: array
                     interface:
                       type: string
                     name:

--- a/config/crd/bases/ptp.openshift.io_ptpconfigs.yaml
+++ b/config/crd/bases/ptp.openshift.io_ptpconfigs.yaml
@@ -38,6 +38,10 @@ spec:
               profile:
                 items:
                   properties:
+                    haProfiles:
+                      items:
+                        type: string
+                      type: array
                     interface:
                       type: string
                     name:

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -383,7 +383,7 @@ spec:
                 - name: RELEASE_VERSION
                   value: v4.16.0
                 - name: LINUXPTP_DAEMON_IMAGE
-                  value: quay.io/openshift/origin-ptp:4.16
+                  value: quay.io/aneeshkp/linuxptp-daemon:416.ha18
                 - name: KUBE_RBAC_PROXY_IMAGE
                   value: quay.io/openshift/origin-kube-rbac-proxy:4.16
                 - name: SIDECAR_EVENT_IMAGE
@@ -394,7 +394,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-                image: quay.io/openshift/origin-ptp-operator:4.16
+                image: quay.io/aneeshkp/ptp-operator:416.ha1
                 imagePullPolicy: IfNotPresent
                 name: ptp-operator
                 ports:

--- a/manifests/stable/ptp.openshift.io_ptpconfigs.yaml
+++ b/manifests/stable/ptp.openshift.io_ptpconfigs.yaml
@@ -37,6 +37,10 @@ spec:
               profile:
                 items:
                   properties:
+                    haProfiles:
+                      items:
+                        type: string
+                      type: array
                     interface:
                       type: string
                     name:


### PR DESCRIPTION
Enabling High Availability (HA) for phc2sys in ptpConfig
This PR   adds haprofile key to ptpConfig to  enable High Availability (HA) for phc2sys . 
It achieves this by adding profiles of ptp4l-enabled configurations under the haProfiles key and passing the socket path of those profiles to phc2sys .
