### PR TITLE
include haprofiles under PTPSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,38 @@ In above examples, `profile1` will be applied by `linuxptp-daemon` to nodes labe
 
 `xxx-ptpconfig` CR is created with `PtpConfig` kind. `spec.profile` defines profile named `profile1` which contains `interface (enp134s0f0)` to run ptp4l process on, `ptp4lOpts (-s -2)` sysconfig options to run ptp4l process with and `phc2sysOpts (-a -r)` to run phc2sys process with. `spec.recommend` defines `priority` (lower numbers mean higher priority, 0 is the highest priority) and `match` rules of profile `profile1`. `priority` is useful when there are multiple `PtpConfig` CRs defined, linuxptp daemon applies `match` rules against node labels and names from high priority to low priority in order. If any of `nodeLabel` or `nodeName` on a specific node matches with the node label or name where daemon runs, it applies profile on that node.
 
+#### ptpConfig to enable High Availability for phc2sys by adding profiles of ptp4l enabled config's under `haProfiles`
+
+```
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+name: suppress-logs-ptpconfig
+namespace: openshift-ptp
+spec:
+phc2sysOpts: "-a -r"
+ptp4lOpts: " "
+profile:
+- name: "enable-ha"
+  ...
+  ...
+  ......
+  ptpSettings:
+    stdoutFilter: "^.*delay   filtered.*$"
+    logReduce: "true"
+    haProfiles: "profile1,profile2"
+  recommend:
+- profile: "enable-ha"
+  priority: 4
+  match:
+    - nodeLabel: "node-role.kubernetes.io/worker"
+
+```
+Requirements:
+Two ptp4l configurations must exist with the phc2sysOPts field set to an empty string.
+The names of these ptp4l configurations will be used and listed under the ptpSettings/haProfiles key in the phc2sys-only enabled ptpConfig.
+
+
 ## Quick Start
 
 To install PTP Operator:

--- a/api/v1/ptpconfig_webhook.go
+++ b/api/v1/ptpconfig_webhook.go
@@ -40,6 +40,7 @@ const (
 
 // log is for logging in this package.
 var ptpconfiglog = logf.Log.WithName("ptpconfig-resource")
+var profileRegEx = regexp.MustCompile(`^(\w+)(,\s*([\w-_]+))`)
 
 func (r *PtpConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -132,6 +133,10 @@ func (r *PtpConfig) validate() error {
 					v = strings.ToLower(v)
 					if v != "true" && v != "false" {
 						return errors.New("logReduce='" + v + "' is invalid; must be in 'true' or 'false'")
+					}
+				case k == "haProfiles":
+					if !profileRegEx.MatchString(v) {
+						return errors.New("haProfiles='" + v + "' is invalid; must be comma seperated profile names")
 					}
 				default:
 					return errors.New("profile.PtpSettings '" + k + "' is not a configurable setting")


### PR DESCRIPTION
Enabling High Availability (HA) for phc2sys in ptpConfig
This PR adds haprofile key to ptpConfig to enable High Availability (HA) for phc2sys .
It achieves this by adding profiles of ptp4l-enabled configurations under the haProfiles key and passing the socket path of those profiles to phc2sys .