### PR TITLE
OCPBUGS-30648: PTP CI TC Failure: PTP socket sharing between pods Run pmc in a new pod on the slave node Should be able to sync using a uds

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -772,8 +772,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 						buf, _, _ := pods.ExecCommand(client.Client, pod, pod.Spec.Containers[0].Name, []string{"pmc", "-u", "-f", "/var/run/ptp4l.0.config", "GET CURRENT_DATA_SET"})
 						return strings.Count(buf.String(), "offsetFromMaster")
 					}, 3*time.Minute, 2*time.Second).Should(BeNumerically(">=", 1))
-					buf, _, _ := pods.ExecCommand(client.Client, pod, pod.Spec.Containers[0].Name, []string{"ls", "-1", "-q", "-A", "/host/secrets/"})
-					Expect(buf.String()).To(Equal(""))
 				})
 			})
 		})


### PR DESCRIPTION
 updated the test assertions to:
   * not assert the contents of /host/secrets directory as it is not affected by the pmc commands in the test stated