### PR TITLE
OCPBUGS-33597: Add automatic leap file update via configmap

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -111,10 +111,11 @@ spec:
               value: "{{ .EnableEventPublisher }}"
             - name: PLUGINS
               value: "{{ .EnabledPlugins }}"
-
           volumeMounts:
             - name: config-volume
               mountPath: /etc/linuxptp
+            - name: leap-volume
+              mountPath: /etc/leap
             - name: socket-dir
               mountPath: /var/run
             {{ if (eq .EnableEventPublisher true) }}
@@ -125,6 +126,9 @@ spec:
         - name: config-volume
           configMap:
             name: ptp-configmap
+        - name: leap-volume
+          configMap:
+            name: leap-configmap            
         - name: linuxptp-certs
           secret:
             secretName: linuxptp-daemon-secret

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -11,6 +11,10 @@ const Namespace = "openshift-ptp"
 // by ptp-operator.
 const DefaultPTPConfigMapName = "ptp-configmap"
 
+// DefaultLeapConfigMapName is the default leap config map that created
+// by ptp-operator.
+const DefaultLeapConfigMapName = "leap-configmap"
+
 // DefaultOperatorConfigName is the default operator config that
 // created by ptp-operator. It's set to the owner of resources of
 // linuxptp daemonset, ptp-configmap and nodePtpDevice.


### PR DESCRIPTION
This commit adds an empty leap-second configmap
that will override leap-seconds.list file on all nodes if populated by user