### PR TITLE
OCPBUGS-34914: remove leapfile from reference config

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ spec:
       ts2phc.pulsewidth 100000000
       #GNSS module s /dev/ttyGNSS* -al use _0
       ts2phc.nmea_serialport  /dev/ttyGNSS_1700_0
-      leapfile  /usr/share/zoneinfo/leap-seconds.list
       [ens2f0]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0


### PR DESCRIPTION
Leapfile is managed by linuxptp-daemon, but still appears in the reference config. This config entry will also be logged, which is misleading. This commit removes the entry from the reference config ts2phcConf section.

/cc @aneeshkp @josephdrichard @jzding @nishant-parekh 