### PR TITLE
Add synceConf and SynceOpts to ptpconfig 

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,35 @@ spec:
       [ens2f0]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0
+    SyncEOpts: " "
+    syncEConf: |
+      [global]
+      logging_level              7
+      use_syslog                 0
+      verbose                    1
+      message_tag                [synce4l]
+      [<synce1>]
+      input_mode                 line
+      network_option             1
+      external_input_QL          11
+      external_input_ext_QL      33
+      extended_tlv               1
+      recover_time               20
+      eec_get_state_cmd         cat /sys/class/net/ens2f0/device/cgu_state
+      eec_holdover_value        4
+      eec_locked_ho_value       3
+      eec_locked_value          2
+      eec_freerun_value         1
+      eec_invalid_value         0
+
+      [ens2f0]
+      tx_heartbeat_msec          1000
+      rx_heartbeat_msec          500
+      recover_clock_enable_cmd   echo 1 0 > /sys/class/net/ens2f0/device/phy/synce
+      recover_clock_disable_cmd  echo 0 0 > /sys/class/net/ens2f0/device/phy/synce
+      allowed_qls                2,11
+      #example config from ReadMe had this triplet: 3,4,7
+      allowed_ext_qls            33, 255
   recommend:
   - profile: "profile1"
     priority: 4

--- a/api/v1/ptpconfig_types.go
+++ b/api/v1/ptpconfig_types.go
@@ -67,9 +67,11 @@ type PtpProfile struct {
 	Ptp4lOpts   *string `json:"ptp4lOpts,omitempty"`
 	Phc2sysOpts *string `json:"phc2sysOpts,omitempty"`
 	Ts2PhcOpts  *string `json:"ts2phcOpts,omitempty"`
+	SyncEOpts   *string `json:"syncEOpts,omitempty"`
 	Ptp4lConf   *string `json:"ptp4lConf,omitempty"`
 	Phc2sysConf *string `json:"phc2sysConf,omitempty"`
 	Ts2PhcConf  *string `json:"ts2phcConf,omitempty"`
+	SyncEConf   *string `json:"syncEConf,omitempty"`
 	// +kubebuilder:validation:Enum=SCHED_OTHER;SCHED_FIFO;
 	PtpSchedulingPolicy *string `json:"ptpSchedulingPolicy,omitempty"`
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -500,6 +500,11 @@ func (in *PtpProfile) DeepCopyInto(out *PtpProfile) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SyncEOpts != nil {
+		in, out := &in.SyncEOpts, &out.SyncEOpts
+		*out = new(string)
+		**out = **in
+	}
 	if in.Ptp4lConf != nil {
 		in, out := &in.Ptp4lConf, &out.Ptp4lConf
 		*out = new(string)
@@ -512,6 +517,11 @@ func (in *PtpProfile) DeepCopyInto(out *PtpProfile) {
 	}
 	if in.Ts2PhcConf != nil {
 		in, out := &in.Ts2PhcConf, &out.Ts2PhcConf
+		*out = new(string)
+		**out = **in
+	}
+	if in.SyncEConf != nil {
+		in, out := &in.SyncEConf, &out.SyncEConf
 		*out = new(string)
 		**out = **in
 	}

--- a/bundle/manifests/ptp.openshift.io_ptpconfigs.yaml
+++ b/bundle/manifests/ptp.openshift.io_ptpconfigs.yaml
@@ -85,6 +85,10 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    syncEConf:
+                      type: string
+                    syncEOpts:
+                      type: string
                     ts2phcConf:
                       type: string
                     ts2phcOpts:

--- a/config/crd/bases/ptp.openshift.io_ptpconfigs.yaml
+++ b/config/crd/bases/ptp.openshift.io_ptpconfigs.yaml
@@ -86,6 +86,10 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    syncEConf:
+                      type: string
+                    syncEOpts:
+                      type: string
                     ts2phcConf:
                       type: string
                     ts2phcOpts:

--- a/manifests/stable/ptp.openshift.io_ptpconfigs.yaml
+++ b/manifests/stable/ptp.openshift.io_ptpconfigs.yaml
@@ -85,6 +85,10 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    syncEConf:
+                      type: string
+                    syncEOpts:
+                      type: string
                     ts2phcConf:
                       type: string
                     ts2phcOpts:


### PR DESCRIPTION
This options are added to ptp config to support syncE functionality in ptp operatoir