### PR TITLE
CNF-13523: nodeptpdevice: Add missing description to spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [Quick Start](#quick-start)
 
 ## PTP Operator
-Ptp Operator, runs in `openshift-ptp` namespace, manages cluster wide PTP configuration. It offers `PtpOperatorConfig` and `PtpConfig` CRDs and creates `linuxptp daemon` to apply node specific PTP config.
+Ptp Operator, runs in `openshift-ptp` namespace, manages cluster wide PTP configuration. It offers `PtpOperatorConfig` and `PtpConfig` CRDs and creates `linuxptp daemon` to apply node-specific PTP config.
 
 ## PtpOperatorConfig
 Upon deployment of PTP Operator, it automatically creates a `default` custom resource of `PtpOperatorConfig` kind which contains a configurable option `daemonNodeSelector`, it is used to specify which nodes `linuxptp daemon` shall be created on. The `daemonNodeSelector` will be applied to `linuxptp daemon` DaemonSet `nodeSelector` field and trigger relaunching of `linuxptp daemon`. Ptp Operator only recognizes `default` `PtpOperatorConfig`, use `oc edit PtpOperatorConfig default -n openshift-ptp` to update the `daemonNodeSelector`.
@@ -303,4 +303,3 @@ To un-install:
 ```
 $ make undeploy
 ```
-

--- a/api/v1/nodeptpdevice_types.go
+++ b/api/v1/nodeptpdevice_types.go
@@ -21,39 +21,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
-// NodePtpDeviceSpec defines the desired state of NodePtpDevice
-type NodePtpDeviceSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-}
-
-type PtpDevice struct {
-	Name    string `json:"name,omitempty"`
-	Profile string `json:"profile,omitempty"`
-}
-
-// NodePtpDeviceStatus defines the observed state of NodePtpDevice
-type NodePtpDeviceStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-	Devices  []PtpDevice `json:"devices,omitempty"`
-	Hwconfig []HwConfig  `json:"hwconfig,omitempty"`
-}
-
-type HwConfig struct {
-	DeviceID string              `json:"deviceID,omitempty"`
-	VendorID string              `json:"vendorID,omitempty"`
-	Failed   bool                `json:"failed,omitempty"`
-	Status   string              `json:"status,omitempty"`
-	Config   *apiextensions.JSON `json:"config,omitempty"`
-}
-
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // NodePtpDevice is the Schema for the nodeptpdevices API
 type NodePtpDevice struct {
@@ -62,6 +32,61 @@ type NodePtpDevice struct {
 
 	Spec   NodePtpDeviceSpec   `json:"spec,omitempty"`
 	Status NodePtpDeviceStatus `json:"status,omitempty"`
+}
+
+// NodePtpDeviceSpec defines the desired state of NodePtpDevice
+type NodePtpDeviceSpec struct {
+}
+
+type PtpDevice struct {
+	// Name is the name of the PTP device.
+	// It is a unique identifier for the device.
+	// +optional
+	Name string `json:"name,omitempty"`
+
+	// Profile is the PTP profile associated with the device.
+	// This profile defines the PTP configuration settings for the device.
+	// +optional
+	Profile string `json:"profile,omitempty"`
+}
+
+type HwConfig struct {
+	// DeviceID is the unique identifier for the hardware device.
+	// +optional
+	DeviceID string `json:"deviceID,omitempty"`
+
+	// VendorID is the identifier for the vendor of the hardware device.
+	// +optional
+	VendorID string `json:"vendorID,omitempty"`
+
+	// Failed indicates whether the hardware configuration has failed.
+	// A value of true means the configuration has failed.
+	// +optional
+	Failed bool `json:"failed,omitempty"`
+
+	// Status provides a descriptive status of the hardware device's configuration.
+	// +optional
+	Status string `json:"status,omitempty"`
+
+	// Config contains the configuration settings for the hardware device.
+	// This is a JSON object that holds the device-specific configuration.
+	// +optional
+	Config *apiextensions.JSON `json:"config,omitempty"`
+}
+
+// NodePtpDeviceStatus defines the observed state of NodePtpDevice
+type NodePtpDeviceStatus struct {
+
+	// PtpDevice represents a PTP device available in the cluster node.
+	// This struct contains information about the device, including its name and profile.
+	// +optional
+	Devices []PtpDevice `json:"devices,omitempty"`
+
+	// HwConfig represents the hardware configuration for a device in the cluster.
+	// This struct contains information about the device's identification and status,
+	// as well as its specific configuration settings.
+	// +optional
+	Hwconfig []HwConfig `json:"hwconfig,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/bundle/manifests/ptp.openshift.io_nodeptpdevices.yaml
+++ b/bundle/manifests/ptp.openshift.io_nodeptpdevices.yaml
@@ -14,7 +14,11 @@ spec:
     singular: nodeptpdevice
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: NodePtpDevice is the Schema for the nodeptpdevices API
@@ -44,28 +48,50 @@ spec:
             properties:
               devices:
                 description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
+                  PtpDevice represents a PTP device available in the cluster node.
+                  This struct contains information about the device, including its name and profile.
                 items:
                   properties:
                     name:
+                      description: |-
+                        Name is the name of the PTP device.
+                        It is a unique identifier for the device.
                       type: string
                     profile:
+                      description: |-
+                        Profile is the PTP profile associated with the device.
+                        This profile defines the PTP configuration settings for the device.
                       type: string
                   type: object
                 type: array
               hwconfig:
+                description: |-
+                  HwConfig represents the hardware configuration for a device in the cluster.
+                  This struct contains information about the device's identification and status,
+                  as well as its specific configuration settings.
                 items:
                   properties:
                     config:
+                      description: |-
+                        Config contains the configuration settings for the hardware device.
+                        This is a JSON object that holds the device-specific configuration.
                       x-kubernetes-preserve-unknown-fields: true
                     deviceID:
+                      description: DeviceID is the unique identifier for the hardware
+                        device.
                       type: string
                     failed:
+                      description: |-
+                        Failed indicates whether the hardware configuration has failed.
+                        A value of true means the configuration has failed.
                       type: boolean
                     status:
+                      description: Status provides a descriptive status of the hardware
+                        device's configuration.
                       type: string
                     vendorID:
+                      description: VendorID is the identifier for the vendor of the
+                        hardware device.
                       type: string
                   type: object
                 type: array

--- a/config/crd/bases/ptp.openshift.io_nodeptpdevices.yaml
+++ b/config/crd/bases/ptp.openshift.io_nodeptpdevices.yaml
@@ -14,7 +14,11 @@ spec:
     singular: nodeptpdevice
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: NodePtpDevice is the Schema for the nodeptpdevices API
@@ -44,28 +48,50 @@ spec:
             properties:
               devices:
                 description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
+                  PtpDevice represents a PTP device available in the cluster node.
+                  This struct contains information about the device, including its name and profile.
                 items:
                   properties:
                     name:
+                      description: |-
+                        Name is the name of the PTP device.
+                        It is a unique identifier for the device.
                       type: string
                     profile:
+                      description: |-
+                        Profile is the PTP profile associated with the device.
+                        This profile defines the PTP configuration settings for the device.
                       type: string
                   type: object
                 type: array
               hwconfig:
+                description: |-
+                  HwConfig represents the hardware configuration for a device in the cluster.
+                  This struct contains information about the device's identification and status,
+                  as well as its specific configuration settings.
                 items:
                   properties:
                     config:
+                      description: |-
+                        Config contains the configuration settings for the hardware device.
+                        This is a JSON object that holds the device-specific configuration.
                       x-kubernetes-preserve-unknown-fields: true
                     deviceID:
+                      description: DeviceID is the unique identifier for the hardware
+                        device.
                       type: string
                     failed:
+                      description: |-
+                        Failed indicates whether the hardware configuration has failed.
+                        A value of true means the configuration has failed.
                       type: boolean
                     status:
+                      description: Status provides a descriptive status of the hardware
+                        device's configuration.
                       type: string
                     vendorID:
+                      description: VendorID is the identifier for the vendor of the
+                        hardware device.
                       type: string
                   type: object
                 type: array

--- a/manifests/stable/ptp.openshift.io_nodeptpdevices.yaml
+++ b/manifests/stable/ptp.openshift.io_nodeptpdevices.yaml
@@ -14,7 +14,11 @@ spec:
     singular: nodeptpdevice
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: NodePtpDevice is the Schema for the nodeptpdevices API
@@ -44,28 +48,50 @@ spec:
             properties:
               devices:
                 description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
+                  PtpDevice represents a PTP device available in the cluster node.
+                  This struct contains information about the device, including its name and profile.
                 items:
                   properties:
                     name:
+                      description: |-
+                        Name is the name of the PTP device.
+                        It is a unique identifier for the device.
                       type: string
                     profile:
+                      description: |-
+                        Profile is the PTP profile associated with the device.
+                        This profile defines the PTP configuration settings for the device.
                       type: string
                   type: object
                 type: array
               hwconfig:
+                description: |-
+                  HwConfig represents the hardware configuration for a device in the cluster.
+                  This struct contains information about the device's identification and status,
+                  as well as its specific configuration settings.
                 items:
                   properties:
                     config:
+                      description: |-
+                        Config contains the configuration settings for the hardware device.
+                        This is a JSON object that holds the device-specific configuration.
                       x-kubernetes-preserve-unknown-fields: true
                     deviceID:
+                      description: DeviceID is the unique identifier for the hardware
+                        device.
                       type: string
                     failed:
+                      description: |-
+                        Failed indicates whether the hardware configuration has failed.
+                        A value of true means the configuration has failed.
                       type: boolean
                     status:
+                      description: Status provides a descriptive status of the hardware
+                        device's configuration.
                       type: string
                     vendorID:
+                      description: VendorID is the identifier for the vendor of the
+                        hardware device.
                       type: string
                   type: object
                 type: array


### PR DESCRIPTION
Adds missing descriptions to the nodeptpdevice spec to improve a bit the user / admin experience with the operand.

/cc @aneeshkp @jzding @josephdrichard 