### PR TITLE
CNF-13531: Add missing field description to ptpoperatorconfig API

### DIFF
--- a/api/v1/ptpoperatorconfig_types.go
+++ b/api/v1/ptpoperatorconfig_types.go
@@ -21,28 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
-// PtpOperatorConfigSpec defines the desired state of PtpOperatorConfig
-type PtpOperatorConfigSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	DaemonNodeSelector map[string]string `json:"daemonNodeSelector"`
-	// EventConfig to configure event sidecar
-	EventConfig    *PtpEventConfig                 `json:"ptpEventConfig,omitempty"`
-	EnabledPlugins *map[string]*apiextensions.JSON `json:"plugins,omitempty"`
-}
-
-// PtpOperatorConfigStatus defines the observed state of PtpOperatorConfig
-type PtpOperatorConfigStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-}
-
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Event Enabled",type="boolean",JSONPath=".spec.ptpEventConfig.enableEventPublisher",description="Event Enabled"
 
 // PtpOperatorConfig is the Schema for the ptpoperatorconfigs API
@@ -54,32 +34,64 @@ type PtpOperatorConfig struct {
 	Status PtpOperatorConfigStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// PtpOperatorConfigSpec defines the desired state of PtpOperatorConfig.
+type PtpOperatorConfigSpec struct {
+	// DaemonNodeSelector specifies the node selector for the linuxptp daemon.
+	// This is a map of key-value pairs used to select the nodes where the
+	// linuxptp daemon will run.
+	// If empty {}, the linuxptp daemon will be deployed on each node of the cluster.
+	// +required
+	DaemonNodeSelector map[string]string `json:"daemonNodeSelector"`
 
-// PtpOperatorConfigList contains a list of PtpOperatorConfig
-type PtpOperatorConfigList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []PtpOperatorConfig `json:"items"`
+	// EventConfig contains the configuration settings for the PTP event sidecar.
+	// This field is optional and can be omitted if event sidecar configuration is not required.
+	// +optional
+	EventConfig *PtpEventConfig `json:"ptpEventConfig,omitempty"`
+
+	// EnabledPlugins is a map of plugin names to their configuration settings.
+	// Each entry in the map specifies the configuration for a specific plugin.
+	// This field is optional and can be omitted if no plugins are enabled.
+	// +optional
+	EnabledPlugins *map[string]*apiextensions.JSON `json:"plugins,omitempty"`
 }
 
 // PtpEventConfig defines the desired state of event framework
 type PtpEventConfig struct {
 	// +kubebuilder:default=false
 	// EnableEventPublisher will deploy event proxy as a sidecar
+	// +optional
 	EnableEventPublisher bool `json:"enableEventPublisher,omitempty"`
+
 	// TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>
 	// Example HTTP transport: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Transport Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Transport Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +optional
 	TransportHost string `json:"transportHost,omitempty"`
+
 	// StorageType is the type of storage to store subscription data
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +optional
 	StorageType string `json:"storageType,omitempty"`
+
 	// ApiVersion is used to determine which API is used for the event service
 	// 1.0: default version. event service is mapped to internal REST-API.
 	// 2.x: event service is mapped to O-RAN v3.0 Compliant O-Cloud Notification REST-API.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ApiVersion",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ApiVersion",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +optional
 	ApiVersion string `json:"apiVersion,omitempty"`
+}
+
+// PtpOperatorConfigStatus defines the observed state of PtpOperatorConfig
+type PtpOperatorConfigStatus struct {
+}
+
+// +kubebuilder:object:root=true
+
+// PtpOperatorConfigList contains a list of PtpOperatorConfig
+type PtpOperatorConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []PtpOperatorConfig `json:"items"`
 }
 
 func init() {

--- a/api/v1/ptpoperatorconfig_types.go
+++ b/api/v1/ptpoperatorconfig_types.go
@@ -24,6 +24,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Event Enabled",type="boolean",JSONPath=".spec.ptpEventConfig.enableEventPublisher",description="Event Enabled"
+// +kubebuilder:validation:XValidation:message="PtpOperatorConfig is a singleton, metadata.name must be 'default'", rule="self.metadata.name == 'default'"
 
 // PtpOperatorConfig is the Schema for the ptpoperatorconfigs API
 type PtpOperatorConfig struct {

--- a/bundle/manifests/ptp.openshift.io_ptpoperatorconfigs.yaml
+++ b/bundle/manifests/ptp.openshift.io_ptpoperatorconfigs.yaml
@@ -42,18 +42,29 @@ spec:
           metadata:
             type: object
           spec:
-            description: PtpOperatorConfigSpec defines the desired state of PtpOperatorConfig
+            description: PtpOperatorConfigSpec defines the desired state of PtpOperatorConfig.
             properties:
               daemonNodeSelector:
                 additionalProperties:
                   type: string
+                description: |-
+                  DaemonNodeSelector specifies the node selector for the linuxptp daemon.
+                  This is a map of key-value pairs used to select the nodes where the
+                  linuxptp daemon will run.
+                  If empty {}, the linuxptp daemon will be deployed on each node of the cluster.
                 type: object
               plugins:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  EnabledPlugins is a map of plugin names to their configuration settings.
+                  Each entry in the map specifies the configuration for a specific plugin.
+                  This field is optional and can be omitted if no plugins are enabled.
                 type: object
               ptpEventConfig:
-                description: EventConfig to configure event sidecar
+                description: |-
+                  EventConfig contains the configuration settings for the PTP event sidecar.
+                  This field is optional and can be omitted if event sidecar configuration is not required.
                 properties:
                   apiVersion:
                     description: |-
@@ -83,6 +94,9 @@ spec:
             description: PtpOperatorConfigStatus defines the observed state of PtpOperatorConfig
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: PtpOperatorConfig is a singleton, metadata.name must be 'default'
+          rule: self.metadata.name == 'default'
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/ptp.openshift.io_ptpoperatorconfigs.yaml
+++ b/config/crd/bases/ptp.openshift.io_ptpoperatorconfigs.yaml
@@ -42,18 +42,29 @@ spec:
           metadata:
             type: object
           spec:
-            description: PtpOperatorConfigSpec defines the desired state of PtpOperatorConfig
+            description: PtpOperatorConfigSpec defines the desired state of PtpOperatorConfig.
             properties:
               daemonNodeSelector:
                 additionalProperties:
                   type: string
+                description: |-
+                  DaemonNodeSelector specifies the node selector for the linuxptp daemon.
+                  This is a map of key-value pairs used to select the nodes where the
+                  linuxptp daemon will run.
+                  If empty {}, the linuxptp daemon will be deployed on each node of the cluster.
                 type: object
               plugins:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  EnabledPlugins is a map of plugin names to their configuration settings.
+                  Each entry in the map specifies the configuration for a specific plugin.
+                  This field is optional and can be omitted if no plugins are enabled.
                 type: object
               ptpEventConfig:
-                description: EventConfig to configure event sidecar
+                description: |-
+                  EventConfig contains the configuration settings for the PTP event sidecar.
+                  This field is optional and can be omitted if event sidecar configuration is not required.
                 properties:
                   apiVersion:
                     description: |-
@@ -83,6 +94,9 @@ spec:
             description: PtpOperatorConfigStatus defines the observed state of PtpOperatorConfig
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: PtpOperatorConfig is a singleton, metadata.name must be 'default'
+          rule: self.metadata.name == 'default'
     served: true
     storage: true
     subresources:

--- a/manifests/stable/ptp.openshift.io_ptpoperatorconfigs.yaml
+++ b/manifests/stable/ptp.openshift.io_ptpoperatorconfigs.yaml
@@ -42,18 +42,29 @@ spec:
           metadata:
             type: object
           spec:
-            description: PtpOperatorConfigSpec defines the desired state of PtpOperatorConfig
+            description: PtpOperatorConfigSpec defines the desired state of PtpOperatorConfig.
             properties:
               daemonNodeSelector:
                 additionalProperties:
                   type: string
+                description: |-
+                  DaemonNodeSelector specifies the node selector for the linuxptp daemon.
+                  This is a map of key-value pairs used to select the nodes where the
+                  linuxptp daemon will run.
+                  If empty {}, the linuxptp daemon will be deployed on each node of the cluster.
                 type: object
               plugins:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  EnabledPlugins is a map of plugin names to their configuration settings.
+                  Each entry in the map specifies the configuration for a specific plugin.
+                  This field is optional and can be omitted if no plugins are enabled.
                 type: object
               ptpEventConfig:
-                description: EventConfig to configure event sidecar
+                description: |-
+                  EventConfig contains the configuration settings for the PTP event sidecar.
+                  This field is optional and can be omitted if event sidecar configuration is not required.
                 properties:
                   apiVersion:
                     description: |-
@@ -83,6 +94,9 @@ spec:
             description: PtpOperatorConfigStatus defines the observed state of PtpOperatorConfig
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: PtpOperatorConfig is a singleton, metadata.name must be 'default'
+          rule: self.metadata.name == 'default'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
This PR revisits the PtpOperatorConfig spec and adds missing field description in API, as well as blocks the creation of extra resources of this type, to avoid confusion among our users.

/cc @aneeshkp @jzding @josephdrichard