### PR TITLE
OCPBUGS-31011: PTP events loses connectivity between producer and consumer when external interface is lost

### DIFF
--- a/bindata/linuxptp/event-service.yaml
+++ b/bindata/linuxptp/event-service.yaml
@@ -9,6 +9,7 @@ metadata:
   name:  ptp-event-publisher-service-{{.NodeName}}
   namespace: openshift-ptp
 spec:
+  clusterIP: None
   selector:
     app: linuxptp-daemon
     nodeName: {{.NodeName}}


### PR DESCRIPTION
When the network goes down, pod to pod communication via service name resolution takes nearly 12 seconds due to dns timeout . Communication resumes as expected once the network is restored.
When you have HostNetwork Pods, the Pods share the same network namespace as the node, meaning they inherit the node's IP address. However, if you want your Service to have a different IP address (i.e., a ClusterIP) that doesn’t expose the node IP
Use a Headless Service with DNS Resolution
    Behavior: A headless service (ClusterIP: None) doesn’t allocate a ClusterIP but still provides DNS resolution for the Pod IPs.
 This won’t give you a different IP, but it will allow you to access Pods directly using the service name.
