### PR TITLE
CI changes to fix L2Discovery Failures on CI lab

### DIFF
--- a/test/pkg/clean/clean.go
+++ b/test/pkg/clean/clean.go
@@ -58,6 +58,7 @@ func Configs() {
 
 	for _, ptpConfig := range ptpconfigList.Items {
 		if ptpConfig.Name == pkg.PtpGrandMasterPolicyName ||
+			ptpConfig.Name == pkg.PtpWPCGrandMasterPolicyName ||
 			ptpConfig.Name == pkg.PtpBcMaster1PolicyName ||
 			ptpConfig.Name == pkg.PtpSlave1PolicyName ||
 			ptpConfig.Name == pkg.PtpBcMaster2PolicyName ||

--- a/test/pkg/consts.go
+++ b/test/pkg/consts.go
@@ -25,12 +25,13 @@ const (
 	EventProxyContainerName         = "cloud-event-proxy"
 
 	// policy name
-	PtpGrandMasterPolicyName = "test-grandmaster"
-	PtpBcMaster1PolicyName   = "test-bc-master1"
-	PtpSlave1PolicyName      = "test-slave1"
-	PtpBcMaster2PolicyName   = "test-bc-master2"
-	PtpSlave2PolicyName      = "test-slave2"
-	PtpTempPolicyName        = "temp"
+	PtpGrandMasterPolicyName    = "test-grandmaster"
+	PtpWPCGrandMasterPolicyName = "test-wpc-grandmaster"
+	PtpBcMaster1PolicyName      = "test-bc-master1"
+	PtpSlave1PolicyName         = "test-slave1"
+	PtpBcMaster2PolicyName      = "test-bc-master2"
+	PtpSlave2PolicyName         = "test-slave2"
+	PtpTempPolicyName           = "temp"
 
 	// node labels
 	PtpGrandmasterNodeLabel    = "ptp/test-grandmaster"

--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -52,7 +52,8 @@ const (
 	// BoundaryClockString matches the BC clock mode in Environement
 	BoundaryClockString = "BC"
 	// DualNICBoundaryClockString matches the DualNICBC clock mode in Environement
-	DualNICBoundaryClockString  = "DualNICBC"
+	DualNICBoundaryClockString = "DualNICBC"
+	// TelcoGrandMasterClockString matches the T-GM clock mode in Environement
 	TelcoGrandMasterClockString = "T-GM"
 	ptp4lEthernet               = "-2 --summary_interval -4"
 	ptp4lEthernetSlave          = "-2 -s --summary_interval -4"
@@ -309,7 +310,7 @@ func GetDesiredConfig(forceUpdate bool) TestConfig {
 		GlobalConfig.Status = InitStatus
 		return GlobalConfig
 	case None:
-		logrus.Infof("No test mode specified using, %s mode. Specify the env variable PTP_TEST_MODE with one of %s, %s, %s, %s", OrdinaryClock, Discovery, OrdinaryClock, BoundaryClock, DualNICBoundaryClockString)
+		logrus.Infof("No test mode specified using, %s mode. Specify the env variable PTP_TEST_MODE with one of %s, %s, %s, %s, %s", OrdinaryClock, Discovery, OrdinaryClock, BoundaryClock, TelcoGrandMasterClock, DualNICBoundaryClockString)
 		GlobalConfig.PtpModeDesired = OrdinaryClock
 		GlobalConfig.Status = InitStatus
 		return GlobalConfig
@@ -411,7 +412,7 @@ func initAndSolveProblems() {
 			{int(solver.StepDifferentNic), 2, 1, 3}}, // step5
 	}
 	data.problems[AlgoTelcoGMString] = &[][][]int{
-		{{int(solver.StepIsPTP), 1, 0}}, // step1
+		{{int(solver.StepIsWPCNic), 1, 0}}, // step1
 	}
 
 	data.problems[AlgoDualNicBCWithSlavesString] = &[][][]int{
@@ -1158,7 +1159,7 @@ func PtpConfigTelcoGM(isExtGM bool) error {
 			logrus.Error("WPC NIC not found in list of interfaces on the cluster")
 			return fmt.Errorf("WPC NIC not found in list of interfaces on the cluster %d", len(IfList))
 		}
-		err := CreatePtpConfigWPCGrandMaster(pkg.PtpGrandMasterPolicyName, gmIf.NodeName, IfList, deviceID)
+		err := CreatePtpConfigWPCGrandMaster(pkg.PtpWPCGrandMasterPolicyName, gmIf.NodeName, IfList, deviceID)
 		if err != nil {
 			logrus.Errorf("Error creating Grandmaster ptpconfig: %s", err)
 		}


### PR DESCRIPTION
    update L2Discovery check for TelcoGM to use WPC NIC check instead of looking for PTP traffic
    update wpc-grand-master ptp profile name to distinguish it from external GM Configuration.