### PR TITLE
[release-4.14] OCPBUGS-53021: fix compile error in CI

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,7 +3,6 @@
 # https://docs.snyk.io/snyk-cli/commands/ignore
 exclude:
   global:
-    # - "vendor/**" # ProdSec encourages not to ignore the entire vendor/* directories
     # - "unpacked_remote_sources/cachito-gomod-with-deps/app/vendor/**"
     - "**/*_test.go"
     - "test/**" # test code only
@@ -12,3 +11,4 @@ exclude:
     - hack # scripts only
     - scripts # scripts only
     - bin # this binary folder is not in git repo. Exclude this when run snyk locally.
+    - vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/ptp-operator
 COPY . .
 ENV GO111MODULE=off

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/ptp-operator
 COPY . .
 ENV GO111MODULE=off


### PR DESCRIPTION
The root cause is a compatibility issue between the expected GLIBC version (2.34) and the available version (2.28) in the builder image. 
Functions like res_hnok and res_dnok, related to DNS name validation in libresolv.so, were in GLIBC 2.34 (RHEL 9) but not in 2.28 (RHEL 8). GLIBC versions in RHEL can be found here https://access.redhat.com/solutions/38634

Dockerfile.rhel7 is used by ART build. This issue seems only occur in CI environment so we keep Dockerfile.rhel7 intact.