### PR TITLE
[release-4.13] OCPBUGS-53022: fix compile error in CI

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-9-golang-1.15-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/ptp-operator/must-gather
 COPY . .
 


### PR DESCRIPTION
The root cause is a compatibility issue between the expected GLIBC version (2.34) and the available version (2.28) in the builder image.
Functions like res_hnok and res_dnok, related to DNS name validation in libresolv.so, were in GLIBC 2.34 (RHEL 9) but not in 2.28 (RHEL 8). GLIBC versions in RHEL can be found here https://access.redhat.com/solutions/38634

Dockerfile.rhel7 is used by ART build. This issue seems only occur in CI environment so we keep Dockerfile.rhel7 intact.