### PR TITLE
OCPBUGS-53021: Revert "fix compile error in CI"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/ptp-operator
 COPY . .
 ENV GO111MODULE=off

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/ptp-operator
 COPY . .
 ENV GO111MODULE=off


### PR DESCRIPTION
This reverts commit c783840876e31ed41e7ef7b265badab3264dbec7.

The rhel8->rhel9 builder fix caused the following issue
```
[kni@hv11 ~]$ oc -n openshift-ptp get pods
NAME                            READY   STATUS             RESTARTS       AGE
podman                          0/1     Completed          0              35m
ptp-operator-79874d6d9d-ckhdw   0/1     CrashLoopBackOff   11 (80s ago)   32m
[kni@hv11 ~]$ oc -n openshift-ptp logs -f ptp-operator-79874d6d9d-ckhdw
ptp-operator: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ptp-operator)
ptp-operator: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by ptp-operator) 
```

CI environment has been updated to fix the original compile issue so this builder change is no longer needed.