### PR TITLE
REDHAT DOWNSTREAM ONLY: fix downstream build

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,12 +1,12 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
-WORKDIR /go/src/github.com/k8snetworkplumbingwg/ptp-operator
+WORKDIR /go/src/github.com/openshift/ptp-operator
 COPY . .
 ENV GO111MODULE=off
 RUN make
 
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
-COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/ptp-operator/build/_output/bin/ptp-operator /usr/local/bin/
-COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/ptp-operator/manifests /manifests
+COPY --from=builder /go/src/github.com/openshift/ptp-operator/build/_output/bin/ptp-operator /usr/local/bin/
+COPY --from=builder /go/src/github.com/openshift/ptp-operator/manifests /manifests
 COPY bindata /bindata
 
 LABEL io.k8s.display-name="OpenShift ptp-operator" \


### PR DESCRIPTION
Downstream builds should import libs from downstream instead of upstream.
For example, after 4.19 split, 4.19 should import libs from 4.19 branches from downstream repo. If it import from upstream it would build an image for main branch instead of 4.19, since upstream is main branch only.