### PR TITLE
Fix must-gather Dockerfile build context and workdir

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,9 +1,0 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
-WORKDIR /go/src/github.com/k8snetworkplumbingwg/ptp-operator/must-gather
-COPY . .
-
-FROM registry.svc.ci.openshift.org/ocp/4.7:must-gather
-COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/ptp-operator/must-gather/collection-scripts/* /usr/bin/
-RUN chmod +x /usr/bin/gather
-
-ENTRYPOINT /usr/bin/gather

--- a/must-gather/Dockerfile.ocp
+++ b/must-gather/Dockerfile.ocp
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
-WORKDIR /go/src/github.com/k8snetworkplumbingwg/ptp-operator/must-gather
-COPY . .
+WORKDIR /go/src/github.com/k8snetworkplumbingwg/ptp-operator
+COPY must-gather/ ./must-gather/
 
 FROM registry.ci.openshift.org/ocp/4.21:must-gather
 LABEL io.k8s.display-name="ptp-operator-must-gather" \


### PR DESCRIPTION
Update WORKDIR to parent project directory and explicitly copy must-gather subdirectory to fix build context issues.
This issue does not affect building the official must-gather image downstream because the downstream build system does not use the Dockerfile defined here. Instead, it uses only the collection scripts.
https://pkgs.devel.redhat.com/cgit/containers/ptp-operator-must-gather/tree/?h=rhaos-4.21-rhel-9