### PR TITLE
CNF-23045: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -3,7 +3,6 @@ package render
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,7 +70,7 @@ func RenderTemplate(path string, d *RenderData) ([]*unstructured.Unstructured, e
 	tmpl.Funcs(template.FuncMap{"getOr": getOr, "isSet": isSet})
 	tmpl.Funcs(sprig.TxtFuncMap())
 
-	source, err := ioutil.ReadFile(path)
+	source, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read manifest %s", path)
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52