### PR TITLE
OCPBUGS-84707: ART: Fix must-gather image reference version

### DIFF
--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:4.22
-    createdAt: "2026-03-18T15:32:00Z"
+    createdAt: "2026-04-28T19:58:20Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -78,7 +78,7 @@ metadata:
     olm.skipRange: ">=4.3.0-0 <4.22.0"
     operatorframework.io/suggested-namespace: openshift-ptp
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.21
+    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.22
     operators.operatorframework.io/builder: operator-sdk-v1.36.1-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -73,7 +73,7 @@ metadata:
     olm.skipRange: ">=4.3.0-0 <4.22.0"
     operatorframework.io/suggested-namespace: openshift-ptp
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.21
+    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.22
     provider: Red Hat
     repository: https://github.com/k8snetworkplumbingwg/ptp-operator
     support: Red Hat

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:4.22
-    createdAt: "2026-03-18T15:32:00Z"
+    createdAt: "2026-04-28T19:58:20Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
     olm.skipRange: ">=4.3.0-0 <4.22.0"
     operatorframework.io/suggested-namespace: openshift-ptp
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.21
+    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.22
     operators.operatorframework.io/builder: operator-sdk-v1.36.1-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat


### PR DESCRIPTION
## Summary
- Update `operators.openshift.io/must-gather-image` annotation in the CSV from `4.21` to `4.22`
- The stale `4.21` reference prevented doozer from resolving and pinning the image during bundle rebase
- This caused Konflux Enterprise Contract verification failures (`olm.allowed_registries` and `olm.unpinned_references`), blocking the prepare-release-konflux pipeline

## Details
The `image-references` file already had the correct `4.22` tag, but the CSV annotation was never updated from `4.21` during the y-stream bump. Without a matching reference, doozer couldn't replace the annotation with a pinned `registry.redhat.io` digest, leaving the raw `quay.io/openshift/origin-ptp-operator-must-gather:4.21` in the built bundle — which EC rejects.

## Test plan
- [ ] Verify bundle builds pass EC verification after this change