### PR TITLE
Minimal bump to 5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.22
+VERSION ?= 5.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -60,8 +60,8 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-ptp-operator:4.22
-    createdAt: "2026-03-18T15:32:00Z"
+    containerImage: quay.io/openshift/origin-ptp-operator:5.0
+    createdAt: "2026-06-17T13:58:33Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -75,16 +75,16 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: ">=4.3.0-0 <4.22.0"
+    olm.skipRange: ">=4.3.0-0 <5.0.0"
     operatorframework.io/suggested-namespace: openshift-ptp
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.21
+    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:5.0
     operators.operatorframework.io/builder: operator-sdk-v1.36.1-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat
     repository: https://github.com/k8snetworkplumbingwg/ptp-operator
     support: Red Hat
-  name: ptp-operator.v4.22.0
+  name: ptp-operator.v5.0.0
   namespace: openshift-ptp
 spec:
   apiservicedefinitions: {}
@@ -363,13 +363,13 @@ spec:
                 - name: OPERATOR_NAME
                   value: ptp-operator
                 - name: RELEASE_VERSION
-                  value: v4.22.0
+                  value: v5.0.0
                 - name: LINUXPTP_DAEMON_IMAGE
-                  value: quay.io/openshift/origin-ptp:4.22
+                  value: quay.io/openshift/origin-ptp:5.0
                 - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:4.22
+                  value: quay.io/openshift/origin-kube-rbac-proxy:5.0
                 - name: SIDECAR_EVENT_IMAGE
-                  value: quay.io/openshift/origin-cloud-event-proxy:4.22
+                  value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -378,7 +378,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-                image: quay.io/openshift/origin-ptp-operator:4.22
+                image: quay.io/openshift/origin-ptp-operator:5.0
                 imagePullPolicy: IfNotPresent
                 name: ptp-operator
                 ports:
@@ -491,7 +491,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 4.22.0
+  version: 5.0.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-06-17T13:58:33Z"
+    createdAt: "2026-06-18T08:45:00Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -367,7 +367,7 @@ spec:
                 - name: LINUXPTP_DAEMON_IMAGE
                   value: quay.io/openshift/origin-ptp:5.0
                 - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:5.0
+                  value: quay.io/openshift/origin-kube-rbac-proxy:4.22
                 - name: SIDECAR_EVENT_IMAGE
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: WATCH_NAMESPACE

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -12,10 +12,10 @@ spec:
             - name: OPERATOR_NAME
               value: "ptp-operator"
             - name: RELEASE_VERSION
-              value: "v4.22.0"
+              value: "v5.0.0"
             - name: LINUXPTP_DAEMON_IMAGE
-              value: "quay.io/openshift/origin-ptp:4.22"
+              value: "quay.io/openshift/origin-ptp:5.0"
             - name: KUBE_RBAC_PROXY_IMAGE
-              value: "quay.io/openshift/origin-kube-rbac-proxy:4.22"
+              value: "quay.io/openshift/origin-kube-rbac-proxy:5.0"
             - name: SIDECAR_EVENT_IMAGE
-              value: "quay.io/openshift/origin-cloud-event-proxy:4.22"
+              value: "quay.io/openshift/origin-cloud-event-proxy:5.0"

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -16,6 +16,6 @@ spec:
             - name: LINUXPTP_DAEMON_IMAGE
               value: "quay.io/openshift/origin-ptp:5.0"
             - name: KUBE_RBAC_PROXY_IMAGE
-              value: "quay.io/openshift/origin-kube-rbac-proxy:5.0"
+              value: "quay.io/openshift/origin-kube-rbac-proxy:4.22"
             - name: SIDECAR_EVENT_IMAGE
               value: "quay.io/openshift/origin-cloud-event-proxy:5.0"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,6 +13,6 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift/origin-ptp-operator
-  newTag: "4.22"
+  newTag: "5.0"
 patchesStrategicMerge:
 - env.yaml

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-ptp-operator:4.22
+    containerImage: quay.io/openshift/origin-ptp-operator:5.0
     createdAt: "2025-09-10"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
@@ -70,10 +70,10 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: ">=4.3.0-0 <4.22.0"
+    olm.skipRange: ">=4.3.0-0 <5.0.0"
     operatorframework.io/suggested-namespace: openshift-ptp
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.21
+    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:5.0
     provider: Red Hat
     repository: https://github.com/k8snetworkplumbingwg/ptp-operator
     support: Red Hat

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,20 +6,20 @@ spec:
   - name: ptp-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ptp-operator:4.22
+      name: quay.io/openshift/origin-ptp-operator:5.0
   - name: ptp
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ptp:4.22
+      name: quay.io/openshift/origin-ptp:5.0
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.22
+      name: quay.io/openshift/origin-kube-rbac-proxy:5.0
   - name: cloud-event-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-cloud-event-proxy:4.22
+      name: quay.io/openshift/origin-cloud-event-proxy:5.0
   - name: ptp-operator-must-gather
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ptp-operator-must-gather:4.22
+      name: quay.io/openshift/origin-ptp-operator-must-gather:5.0

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -60,8 +60,8 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-ptp-operator:4.22
-    createdAt: "2026-03-18T15:32:00Z"
+    containerImage: quay.io/openshift/origin-ptp-operator:5.0
+    createdAt: "2026-06-17T13:58:33Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -75,16 +75,16 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: ">=4.3.0-0 <4.22.0"
+    olm.skipRange: ">=4.3.0-0 <5.0.0"
     operatorframework.io/suggested-namespace: openshift-ptp
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:4.21
+    operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:5.0
     operators.operatorframework.io/builder: operator-sdk-v1.36.1-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat
     repository: https://github.com/k8snetworkplumbingwg/ptp-operator
     support: Red Hat
-  name: ptp-operator.v4.22.0
+  name: ptp-operator.v5.0.0
   namespace: openshift-ptp
 spec:
   apiservicedefinitions: {}
@@ -363,13 +363,13 @@ spec:
                 - name: OPERATOR_NAME
                   value: ptp-operator
                 - name: RELEASE_VERSION
-                  value: v4.22.0
+                  value: v5.0.0
                 - name: LINUXPTP_DAEMON_IMAGE
-                  value: quay.io/openshift/origin-ptp:4.22
+                  value: quay.io/openshift/origin-ptp:5.0
                 - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:4.22
+                  value: quay.io/openshift/origin-kube-rbac-proxy:5.0
                 - name: SIDECAR_EVENT_IMAGE
-                  value: quay.io/openshift/origin-cloud-event-proxy:4.22
+                  value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -378,7 +378,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-                image: quay.io/openshift/origin-ptp-operator:4.22
+                image: quay.io/openshift/origin-ptp-operator:5.0
                 imagePullPolicy: IfNotPresent
                 name: ptp-operator
                 ports:
@@ -491,7 +491,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 4.22.0
+  version: 5.0.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-06-17T13:58:33Z"
+    createdAt: "2026-06-18T08:45:00Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -367,7 +367,7 @@ spec:
                 - name: LINUXPTP_DAEMON_IMAGE
                   value: quay.io/openshift/origin-ptp:5.0
                 - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:5.0
+                  value: quay.io/openshift/origin-kube-rbac-proxy:4.22
                 - name: SIDECAR_EVENT_IMAGE
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: WATCH_NAMESPACE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded the PTP Operator to **v5.0.0** and aligned related component images and runtime settings (daemon, event sidecar, and controller release version).
  * Updated ClusterServiceVersion and ImageStream metadata to match the **5.0** release, including the **must-gather** image tag and the supported upgrade **skip range**.
  * Adjusted the default build/release version used when no override is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->