### PR TITLE
Bump version and images to 5.0

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/ptp-operator
 COPY . .
 ENV GO111MODULE=off
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/ptp-operator/build/_output/bin/ptp-operator /usr/local/bin/
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/ptp-operator/manifests /manifests
 COPY bindata /bindata

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/ptp-operator
 COPY . .
 ENV GO111MODULE=auto
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/ptp-operator/build/_output/bin/ptp-operator /usr/local/bin/
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/ptp-operator/manifests /manifests
 COPY bindata /bindata

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-06-18T08:45:00Z"
+    createdAt: "2026-06-22T17:43:51Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -367,7 +367,7 @@ spec:
                 - name: LINUXPTP_DAEMON_IMAGE
                   value: quay.io/openshift/origin-ptp:5.0
                 - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:4.22
+                  value: quay.io/openshift/origin-kube-rbac-proxy:5.0
                 - name: SIDECAR_EVENT_IMAGE
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: WATCH_NAMESPACE

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -16,6 +16,6 @@ spec:
             - name: LINUXPTP_DAEMON_IMAGE
               value: "quay.io/openshift/origin-ptp:5.0"
             - name: KUBE_RBAC_PROXY_IMAGE
-              value: "quay.io/openshift/origin-kube-rbac-proxy:4.22"
+              value: "quay.io/openshift/origin-kube-rbac-proxy:5.0"
             - name: SIDECAR_EVENT_IMAGE
               value: "quay.io/openshift/origin-cloud-event-proxy:5.0"

--- a/controllers/tls_profile_test.go
+++ b/controllers/tls_profile_test.go
@@ -66,7 +66,7 @@ func makeTestRenderData() *render.RenderData {
 	data.Data["Image"] = "test-image"
 	data.Data["ImagePullPolicy"] = "IfNotPresent"
 	data.Data["Namespace"] = "openshift-ptp"
-	data.Data["ReleaseVersion"] = "4.22.0"
+	data.Data["ReleaseVersion"] = "5.0.0"
 	data.Data["KubeRbacProxy"] = "test-rbac-proxy"
 	data.Data["SideCar"] = "test-sidecar"
 	data.Data["NodeName"] = "test-node"

--- a/hack/env.sh
+++ b/hack/env.sh
@@ -2,7 +2,7 @@ REPO_DIR="$(dirname $0)/.."
 NAMESPACE=openshift-ptp
 OPERATOR_EXEC=oc
 
-export RELEASE_VERSION=v4.22.0
+export RELEASE_VERSION=v5.0.0
 export IMAGE_TAG=latest
 export OPERATOR_NAME=ptp-operator
 

--- a/manifests/ptp-operator.package.yaml
+++ b/manifests/ptp-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: ptp-operator
 channels:
 - name: stable
-  currentCSV: ptp-operator.v4.22.0
+  currentCSV: ptp-operator.v5.0.0

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-06-18T08:45:00Z"
+    createdAt: "2026-06-22T17:43:51Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -367,7 +367,7 @@ spec:
                 - name: LINUXPTP_DAEMON_IMAGE
                   value: quay.io/openshift/origin-ptp:5.0
                 - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:4.22
+                  value: quay.io/openshift/origin-kube-rbac-proxy:5.0
                 - name: SIDECAR_EVENT_IMAGE
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: WATCH_NAMESPACE

--- a/ptp-tools/scripts/customize-env.sh
+++ b/ptp-tools/scripts/customize-env.sh
@@ -18,7 +18,7 @@ spec:
             - name: OPERATOR_NAME
               value: "ptp-operator"
             - name: RELEASE_VERSION
-              value: "v4.22.0"
+              value: "v5.0.0"
             - name: LINUXPTP_DAEMON_IMAGE
               value: "$IMG_PREFIX:lptpd"
             - name: KUBE_RBAC_PROXY_IMAGE

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "4.22.0"
+	Version = "5.0.0"
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated PTP operator to version 5.0.0
* Upgraded builder and runtime container images to latest stable versions
* Updated operator manifests and configurations to reference new version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->