### PR TITLE
Fix unbound variable in upstream-sync.sh when SKIP_PRS is empty

### DIFF
--- a/hack/upstream-sync.sh
+++ b/hack/upstream-sync.sh
@@ -278,9 +278,13 @@ should_skip_pr() {
 filter_skipped() {
   log "Filtering PRs for skip conditions..."
 
-  local skip_pr_list skip_commit_list
-  IFS=',' read -ra skip_pr_list <<< "${SKIP_PRS:-}"
-  IFS=',' read -ra skip_commit_list <<< "${SKIP_COMMITS:-}"
+  local skip_pr_list=() skip_commit_list=()
+  if [[ -n "${SKIP_PRS:-}" ]]; then
+    IFS=',' read -ra skip_pr_list <<< "$SKIP_PRS"
+  fi
+  if [[ -n "${SKIP_COMMITS:-}" ]]; then
+    IFS=',' read -ra skip_commit_list <<< "$SKIP_COMMITS"
+  fi
 
   local kept_prs="[]"
   local skipped_prs="[]"
@@ -295,15 +299,17 @@ filter_skipped() {
 
     local skip_reason=""
 
-    for skip_num in "${skip_pr_list[@]}"; do
-      skip_num="${skip_num// /}"
-      if [ -n "$skip_num" ] && [ "$skip_num" = "$pr_number" ]; then
-        skip_reason="manually skipped (SKIP_PRS)"
-        break
-      fi
-    done
+    if [[ ${#skip_pr_list[@]} -gt 0 ]]; then
+      for skip_num in "${skip_pr_list[@]}"; do
+        skip_num="${skip_num// /}"
+        if [ -n "$skip_num" ] && [ "$skip_num" = "$pr_number" ]; then
+          skip_reason="manually skipped (SKIP_PRS)"
+          break
+        fi
+      done
+    fi
 
-    if [ -z "$skip_reason" ]; then
+    if [ -z "$skip_reason" ] && [[ ${#skip_commit_list[@]} -gt 0 ]]; then
       for skip_sha in "${skip_commit_list[@]}"; do
         skip_sha="${skip_sha// /}"
         if [ -n "$skip_sha" ] && [[ "$pr_sha" == ${skip_sha}* ]]; then


### PR DESCRIPTION
## Summary
Fix `upstream-sync.sh` crashing with `unbound variable` error when `SKIP_PRS` and `SKIP_COMMITS` env vars are not set.

## Problem
Under `set -u`, `IFS=',' read -ra skip_pr_list <<< ""` creates an array that fails when iterated with `"${arr[@]}"`:
```
./hack/upstream-sync.sh: line 278: skip_pr_list[@]: unbound variable
```

## Fix
- Initialize arrays empty `=()`
- Only populate via `read -ra` when the env var is non-empty
- Guard loop iteration with `${#arr[@]} -gt 0` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skip handling during upstream syncs so empty skip settings are ignored safely.
  * Manual skip rules for pull requests and commit IDs now apply more consistently, reducing unexpected behavior when no values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->