### PR TITLE
CNF-25274: Add minKubeVersion to CSV for OCP 5.0 certification

### DIFF
--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-06-25T00:57:11Z"
+    createdAt: "2026-07-02T18:03:02Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -493,6 +493,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat
   maturity: alpha
+  minKubeVersion: 1.35.0
   provider:
     name: Red Hat
   version: 5.0.0

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -175,6 +175,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat
   maturity: alpha
+  minKubeVersion: 1.35.0
   provider:
     name: Red Hat
   version: 0.0.0

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-06-25T00:57:11Z"
+    createdAt: "2026-07-02T18:03:02Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -493,6 +493,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat
   maturity: alpha
+  minKubeVersion: 1.35.0
   provider:
     name: Red Hat
   version: 5.0.0

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -2455,6 +2455,112 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				}
 			})
 
+			It("Verify ts2phc clock state is not LOCKED after GM PtpConfig is deleted", func() {
+				By("Verifying ts2phc clock state is LOCKED")
+				checkClockStateForProcess(fullConfig, "ts2phc", "1")
+
+				Expect(testconfig.GlobalConfig.DiscoveredGrandMasterPtpConfig).NotTo(BeNil(),
+					"DiscoveredGrandMasterPtpConfig must not be nil")
+				gmConfigName := testconfig.GlobalConfig.DiscoveredGrandMasterPtpConfig.Name
+
+				By(fmt.Sprintf("Deleting GM PtpConfig %s", gmConfigName))
+				err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Delete(
+					context.Background(), gmConfigName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				DeferCleanup(func() {
+					By("Recreating GM PtpConfig after test")
+					ensureGMPtpConfigRestored()
+				})
+
+				By("Waiting for ts2phc clock state metric to be removed")
+				Eventually(func() bool {
+					buf, _, _ := pods.ExecCommand(client.Client, true,
+						fullConfig.DiscoveredClockUnderTestPod, pkg.PtpContainerName,
+						[]string{"curl", pkg.MetricsEndPoint})
+					metricsOutput := buf.String()
+					if !strings.Contains(metricsOutput, "# HELP") {
+						return false
+					}
+					_, found := getClockStateByProcess(metricsOutput, "ts2phc")
+					return !found
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(BeTrue(),
+					"Expected ts2phc clock state metric to be removed after GM PtpConfig deletion")
+			})
+
+			It("Verify ts2phc metrics are cleaned up after GM PtpConfig delete and re-apply", func() {
+				Expect(testconfig.GlobalConfig.DiscoveredGrandMasterPtpConfig).NotTo(BeNil(),
+					"DiscoveredGrandMasterPtpConfig must not be nil")
+				gmConfigName := testconfig.GlobalConfig.DiscoveredGrandMasterPtpConfig.Name
+
+				By("Ensuring ts2phc is running and recording its config file name and restart count")
+				var initialConfigName string
+				var initialRestartCount int
+				Eventually(func() bool {
+					buf, _, _ := pods.ExecCommand(client.Client, true,
+						fullConfig.DiscoveredClockUnderTestPod, pkg.PtpContainerName,
+						[]string{"curl", pkg.MetricsEndPoint})
+					initialConfigName, initialRestartCount, _ = getProcessConfigAndRestartCount(buf.String(), "ts2phc")
+					return initialConfigName != ""
+				}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeTrue(),
+					"ts2phc process_status with config name not found in metrics")
+				fmt.Fprintf(GinkgoWriter, "Initial ts2phc config=%s, restart_count=%d\n",
+					initialConfigName, initialRestartCount)
+
+				By(fmt.Sprintf("Deleting GM PtpConfig %s", gmConfigName))
+				err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Delete(
+					context.Background(), gmConfigName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				DeferCleanup(func() {
+					By("Ensuring GM PtpConfig is restored after test")
+					ensureGMPtpConfigRestored()
+				})
+
+				By("Waiting for ts2phc process to stop after deletion")
+				Eventually(func() bool {
+					buf, _, _ := pods.ExecCommand(client.Client, true,
+						fullConfig.DiscoveredClockUnderTestPod, pkg.PtpContainerName,
+						[]string{"curl", pkg.MetricsEndPoint})
+					metricsOutput := buf.String()
+					if !strings.Contains(metricsOutput, "# HELP") {
+						return false
+					}
+					configName, _, _ := getProcessConfigAndRestartCount(metricsOutput, "ts2phc")
+					return configName == ""
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(BeTrue(),
+					"ts2phc process did not stop after GM PtpConfig deletion")
+
+				By("Re-applying the same GM PtpConfig")
+				tempPtpConfig := (*ptpv1.PtpConfig)(testconfig.GlobalConfig.DiscoveredGrandMasterPtpConfig)
+				tempPtpConfig.SetResourceVersion("")
+				_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Create(
+					context.Background(), tempPtpConfig, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting for ts2phc to come back up after re-apply")
+				var newConfigName string
+				var newRestartCount int
+				Eventually(func() bool {
+					buf, _, _ := pods.ExecCommand(client.Client, true,
+						fullConfig.DiscoveredClockUnderTestPod, pkg.PtpContainerName,
+						[]string{"curl", pkg.MetricsEndPoint})
+					newConfigName, newRestartCount, _ = getProcessConfigAndRestartCount(buf.String(), "ts2phc")
+					return newConfigName != ""
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(BeTrue(),
+					"ts2phc did not come back up after GM PtpConfig re-apply")
+				fmt.Fprintf(GinkgoWriter, "After re-apply: ts2phc config=%s, restart_count=%d\n",
+					newConfigName, newRestartCount)
+
+				By("Verifying config name is preserved and metrics are consistent after re-apply")
+				Expect(newConfigName).To(Equal(initialConfigName),
+					fmt.Sprintf("ts2phc config name should be preserved after re-apply, got %s (initial was %s)",
+						newConfigName, initialConfigName))
+				Expect(newRestartCount).To(BeNumerically(">=", initialRestartCount),
+					fmt.Sprintf("ts2phc restart count should continue after re-apply (not reset), got %d (initial was %d)",
+						newRestartCount, initialRestartCount))
+			})
+
 		})
 
 		Context("WPC GM GNSS signal loss tests", func() {
@@ -3621,6 +3727,50 @@ func getProcessStatusByProcess(metricsText, process string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// ensureGMPtpConfigRestored is a DeferCleanup helper that recreates the GM PtpConfig
+// if it was deleted during a test, ensuring subsequent tests have a valid configuration.
+func ensureGMPtpConfigRestored() {
+	tempPtpConfig := (*ptpv1.PtpConfig)(testconfig.GlobalConfig.DiscoveredGrandMasterPtpConfig)
+	tempPtpConfig.SetResourceVersion("")
+	_, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Create(
+		context.Background(), tempPtpConfig, metav1.CreateOptions{})
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+// getProcessConfigAndRestartCount parses the metrics output for a given process and returns
+// its config file name (from process_status with value 1) and restart count.
+func getProcessConfigAndRestartCount(metricsText, process string) (configName string, restartCount int, found bool) {
+	processFilter := fmt.Sprintf(`process="%s"`, process)
+	scanner := bufio.NewScanner(strings.NewReader(metricsText))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, metrics.OpenshiftPtpProcessStatus) && strings.Contains(line, processFilter) {
+			parts := strings.Fields(line)
+			if len(parts) == 2 && parts[1] == "1" {
+				start := strings.Index(line, `config="`) + len(`config="`)
+				end := strings.Index(line[start:], `"`)
+				if end > 0 {
+					configName = line[start : start+end]
+					found = true
+				}
+			}
+		}
+		if strings.HasPrefix(line, metrics.OpenshiftPtpProcessRestartCount) && strings.Contains(line, processFilter) {
+			parts := strings.Fields(line)
+			if len(parts) == 2 {
+				var parseErr error
+				restartCount, parseErr = strconv.Atoi(parts[1])
+				if parseErr != nil {
+					fmt.Fprintf(GinkgoWriter, "WARN: could not parse restart_count %q for process %s: %v\n", parts[1], process, parseErr)
+				}
+			}
+		}
+	}
+	return configName, restartCount, found
 }
 
 // checkStatusByProcess mirrors checkClockStateForProcess but for process status (1/0)

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -2239,6 +2239,21 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 				logrus.Info("Successfully verified T-BC clock class recovery after upstream link outage")
 			})
+
+			It("Should restart ptp4l with no socket errors after SIGTERM", func() {
+				verifyProcessRestartNoSocketErrors(fullConfig, "ptp4l")
+			})
+
+			It("Should restart phc2sys with no socket errors after SIGTERM", func() {
+				verifyProcessRestartNoSocketErrors(fullConfig, "phc2sys")
+			})
+
+			It("Should restart ts2phc with no socket errors after SIGTERM", func() {
+				if fullConfig.PtpModeDiscovered != testconfig.TelcoGrandMasterClock {
+					Skip("ts2phc only runs in GM configuration")
+				}
+				verifyProcessRestartNoSocketErrors(fullConfig, "ts2phc")
+			})
 		})
 
 		Context("WPC GM Verification Tests", func() {
@@ -3771,6 +3786,46 @@ func getProcessConfigAndRestartCount(metricsText, process string) (configName st
 		}
 	}
 	return configName, restartCount, found
+}
+
+// verifyProcessRestartNoSocketErrors sends SIGTERM to the given PTP process, waits for a
+// 1→0→1 metric restart cycle, and asserts no event-socket errors appear in the daemon logs.
+func verifyProcessRestartNoSocketErrors(fullConfig testconfig.TestConfig, process string) {
+	By(fmt.Sprintf("Verifying %s is running (process status == 1)", process))
+	checkStatusByProcess(fullConfig, process, "1")
+
+	beforeKill := time.Now()
+	time.Sleep(1 * time.Second)
+
+	By(fmt.Sprintf("Starting metric watcher and killing %s", process))
+	watchDone := make(chan bool, 1)
+	go func() {
+		watchDone <- watchProcessFlipOneZeroOne(fullConfig, process, 60*time.Second)
+	}()
+	time.Sleep(1 * time.Second)
+
+	_, _, err := pods.ExecCommand(client.Client, true,
+		fullConfig.DiscoveredClockUnderTestPod, pkg.PtpContainerName,
+		[]string{"sh", "-c", fmt.Sprintf("pkill -TERM %s || true", process)})
+	Expect(err).To(BeNil(), fmt.Sprintf("failed to kill %s", process))
+
+	By(fmt.Sprintf("Waiting for %s process_status 1→0→1 metric flip", process))
+	Eventually(watchDone, 60*time.Second, 1*time.Second).Should(Receive(BeTrue()),
+		fmt.Sprintf("%s did not complete 1→0→1 restart cycle", process))
+
+	By("Checking daemon logs for socket errors after the kill")
+	time.Sleep(5 * time.Second)
+	socketErrMatches, _ := pods.GetPodLogsRegexSince(
+		openshiftPtpNamespace,
+		fullConfig.DiscoveredClockUnderTestPod.Name,
+		pkg.PtpContainerName,
+		`error trying to connect to event socket|Failed to reconnect to event socket|Reconnect failed after write error|Write error for|Write failed again after reconnect`,
+		false,
+		2*time.Second,
+		beforeKill,
+	)
+	Expect(socketErrMatches).To(BeEmpty(),
+		fmt.Sprintf("unexpected socket errors in logs after %s kill: %v", process, socketErrMatches))
 }
 
 // checkStatusByProcess mirrors checkClockStateForProcess but for process status (1/0)

--- a/test/pkg/metrics/metrics.go
+++ b/test/pkg/metrics/metrics.go
@@ -17,19 +17,20 @@ import (
 )
 
 const (
-	OpenshiftPtpInterfaceRole   = "openshift_ptp_interface_role"
-	OpenshiftPtpClockState      = "openshift_ptp_clock_state"
-	OpenshiftPtpFrequencyStatus = "openshift_ptp_frequency_status"
-	OpenshiftPtpPhaseStatus     = "openshift_ptp_phase_status"
-	OpenshiftPtpOffsetNs        = "openshift_ptp_offset_ns"
-	OpenshiftPtpProcessStatus   = "openshift_ptp_process_status"
-	OpenshiftPtpClockClass      = "openshift_ptp_clock_class"
-	OpenshiftPtpNMEAStatus      = "openshift_ptp_nmea_status"
-	OpenshiftPtpThreshold       = "openshift_ptp_threshold"
-	metricsEndPoint             = "127.0.0.1:9091/metrics"
-	MaxOffsetDefaultNs          = 100
-	MinOffsetDefaultNs          = -100
-	MaxInSpecOffsetDefaultNs    = 100
+	OpenshiftPtpInterfaceRole       = "openshift_ptp_interface_role"
+	OpenshiftPtpClockState          = "openshift_ptp_clock_state"
+	OpenshiftPtpFrequencyStatus     = "openshift_ptp_frequency_status"
+	OpenshiftPtpPhaseStatus         = "openshift_ptp_phase_status"
+	OpenshiftPtpOffsetNs            = "openshift_ptp_offset_ns"
+	OpenshiftPtpProcessStatus       = "openshift_ptp_process_status"
+	OpenshiftPtpClockClass          = "openshift_ptp_clock_class"
+	OpenshiftPtpNMEAStatus          = "openshift_ptp_nmea_status"
+	OpenshiftPtpThreshold           = "openshift_ptp_threshold"
+	OpenshiftPtpProcessRestartCount = "openshift_ptp_process_restart_count"
+	metricsEndPoint                 = "127.0.0.1:9091/metrics"
+	MaxOffsetDefaultNs              = 100
+	MinOffsetDefaultNs              = -100
+	MaxInSpecOffsetDefaultNs        = 100
 )
 
 var MaxOffsetNs int


### PR DESCRIPTION
## Summary
- Add `minKubeVersion: 1.35.0` to CSV spec, matching the K8s API version (v0.35.2) used by OCP 4.22/5.0
- Ensures the operator only installs on clusters with compatible Kubernetes versions
- Bundle passes `operator-sdk bundle validate`
- `olm.skipRange: ">=4.3.0-0 <5.0.0"` verified correct for upgrades from any 4.x on both OCP 4.22 and 5.0

Fixes: [CNF-25274](https://redhat.atlassian.net/browse/CNF-25274)

## Test plan
- [x] `make bundle` succeeds (includes `operator-sdk bundle validate`)
- [x] `minKubeVersion: 1.35.0` present in all 3 CSV files (template, bundle, stable)
- [x] `olm.skipRange` unchanged at `>=4.3.0-0 <5.0.0`
- [ ] Verify operator installs correctly on OCP 4.22 cluster
- [ ] Verify operator installs correctly on OCP 5.0 cluster
- [ ] Verify operator appears in OperatorHub on both versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a minimum Kubernetes version requirement for installing the operator.

* **Bug Fixes**
  * Improved restart handling checks for key timing components to ensure they recover cleanly without socket-related errors.
  * Added validation for configuration removal and restoration flows so components return consistently after changes.

* **Tests**
  * Expanded conformance coverage for restart behavior and configuration lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->